### PR TITLE
feat #1: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/gogoring/dongoorami/DongooramiApplication.java
+++ b/src/main/java/com/gogoring/dongoorami/DongooramiApplication.java
@@ -2,7 +2,9 @@ package com.gogoring.dongoorami;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DongooramiApplication {
 

--- a/src/main/java/com/gogoring/dongoorami/global/common/BaseEntity.java
+++ b/src/main/java/com/gogoring/dongoorami/global/common/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.gogoring.dongoorami.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_activated")
+    private boolean isActivated = true;
+}

--- a/src/main/java/com/gogoring/dongoorami/global/config/RedisConfig.java
+++ b/src/main/java/com/gogoring/dongoorami/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.gogoring.dongoorami.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
+++ b/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.gogoring.dongoorami.global.config;
+
+import com.gogoring.dongoorami.global.jwt.JwtAccessDeniedHandler;
+import com.gogoring.dongoorami.global.jwt.JwtAuthenticationEntryPoint;
+import com.gogoring.dongoorami.global.jwt.JwtAuthenticationFilter;
+import com.gogoring.dongoorami.global.oauth2.CustomOAuth2UserService;
+import com.gogoring.dongoorami.global.oauth2.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+                .csrf(CsrfConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        requests -> requests.anyRequest().permitAll()
+                )
+                .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .oauth2Login(oauth2LoginConfigurer -> oauth2LoginConfigurer
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler));
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/CustomUserDetails.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/CustomUserDetails.java
@@ -1,0 +1,51 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return member.getRoles()
+                .stream()
+                .map(role -> new SimpleGrantedAuthority(role.name()))
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getProviderId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return member.isActivated();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import com.gogoring.dongoorami.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByProviderIdAndIsActivatedIsTrue(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보가 존재하지 않습니다."));
+
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("Forbidden Request : {}", request.getRequestURI());
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("Unauthorized Request : {}", request.getRequestURI());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && tokenProvider.validateAccessToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/jwt/TokenProvider.java
+++ b/src/main/java/com/gogoring/dongoorami/global/jwt/TokenProvider.java
@@ -1,0 +1,170 @@
+package com.gogoring.dongoorami.global.jwt;
+
+import com.gogoring.dongoorami.member.repository.TokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private final TokenRepository tokenRepository;
+
+    private final String secret;
+    private final Long accessExpirationTime;
+    private final Long refreshExpirationTime;
+    private Key key;
+
+    public TokenProvider(CustomUserDetailsService customUserDetailsService,
+                         TokenRepository tokenRepository,
+                         @Value("${jwt.secret}") String secret,
+                         @Value("${jwt.access-expiration-time}") Long accessExpirationTime,
+                         @Value("${jwt.refresh-expiration-time}") Long refreshExpirationTime) {
+        this.customUserDetailsService = customUserDetailsService;
+        this.tokenRepository = tokenRepository;
+        this.secret = secret;
+        this.accessExpirationTime = accessExpirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(String providerId, List<GrantedAuthority> grantedAuthorities) {
+
+        String authorities = grantedAuthorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Claims claims = Jwts.claims()
+                .setSubject(providerId);
+        claims.put("authorities", authorities);
+
+        Date expirationTime = getExpirationTime(accessExpirationTime);
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expirationTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TOKEN_PREFIX + accessToken;
+    }
+
+    public String createRefreshToken(String providerId) {
+
+        Claims claims = Jwts.claims()
+                .setSubject(providerId);
+
+        Date expirationTime = getExpirationTime(refreshExpirationTime);
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expirationTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        Duration duration = Duration.between(Instant.now(), expirationTime.toInstant());
+        tokenRepository.save(providerId, refreshToken, duration);
+
+        return refreshToken;
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String providerId = parseClaims(token).getSubject();
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(providerId);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
+    }
+
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            Claims claims = parseClaims(accessToken);
+            String signOutToken = tokenRepository.findByKey(accessToken);
+
+            return !claims.getExpiration().before(new Date()) && (signOutToken == null);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 JWT입니다.", e);
+        }
+
+        return false;
+    }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Claims claims = parseClaims(refreshToken);
+
+            String providerId = claims.getSubject();
+            String savedRefreshToken = tokenRepository.findByKey(providerId);
+
+            return refreshToken.equals(savedRefreshToken);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 JWT입니다.", e);
+        }
+
+        return false;
+    }
+
+    public String getProviderId(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public Duration getRestExpirationTime(String token) {
+        return Duration.between(Instant.now(), parseClaims(token).getExpiration().toInstant());
+    }
+
+    public String getTokenWithNoPrefix(String accessToken) {
+        return accessToken.replace(TOKEN_PREFIX, "");
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Date getExpirationTime(Long expirationTime) {
+        return new Date((new Date()).getTime() + expirationTime);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,41 @@
+package com.gogoring.dongoorami.global.oauth2;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@AllArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private String provider;
+    private Map<String, Object> attributes;
+    private List<GrantedAuthority> authorities;
+    private String providerId;
+    private Member member;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.authorities;
+    }
+
+    @Override
+    public String getName() {
+        return this.provider;
+    }
+
+    public String getProviderId() {
+        return this.providerId;
+    }
+
+    public Member getMember() {
+        return this.member;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,49 @@
+package com.gogoring.dongoorami.global.oauth2;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import com.gogoring.dongoorami.member.domain.Role;
+import com.gogoring.dongoorami.member.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        OAuth2UserInfo oAuth2UserInfo = null;
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        if (provider.equals("kakao")) {
+            oAuth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        }
+
+        Member member = saveOrUpdate(oAuth2UserInfo);
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (Role role : member.getRoles()) {
+            authorities.add(new SimpleGrantedAuthority(role.name()));
+        }
+
+        return new CustomOAuth2User(provider, oAuth2User.getAttributes(), authorities,
+                member.getProviderId(), member);
+    }
+
+    private Member saveOrUpdate(OAuth2UserInfo oAuth2UserInfo) {
+        Member member = memberRepository.findByProviderIdAndIsActivatedIsTrue(oAuth2UserInfo.getProviderId())
+                .map(entity -> entity.updateName(oAuth2UserInfo.getName()))
+                .orElse(oAuth2UserInfo.toEntity());
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/KakaoUserInfo.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/KakaoUserInfo.java
@@ -1,0 +1,40 @@
+package com.gogoring.dongoorami.global.oauth2;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class KakaoUserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getName() {
+        return (String)((Map)((Map)attributes.get("kakao_account")).get("profile")).get("nickname");
+    }
+
+    @Override
+    public String getProfileImage() {
+        return (String)((Map)((Map)attributes.get("kakao_account")).get("profile")).get("profile_image_url");
+    }
+
+    @Override
+    public Member toEntity() {
+        return Member.builder()
+                .name(getName())
+                .profileImage(getProfileImage())
+                .provider(getProvider())
+                .providerId(getProviderId())
+                .build();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,52 @@
+package com.gogoring.dongoorami.global.oauth2;
+
+import com.gogoring.dongoorami.global.jwt.TokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        String accessToken = tokenProvider.createAccessToken(oAuth2User.getProviderId(),
+                (List<GrantedAuthority>) oAuth2User.getAuthorities());
+        String refreshToken = tokenProvider.createRefreshToken(oAuth2User.getProviderId());
+        Boolean isFirstLogin = oAuth2User.getMember().getBirthDate() == null;
+        String uri = createURI(accessToken, refreshToken, isFirstLogin);
+
+        getRedirectStrategy().sendRedirect(request, response, uri);
+    }
+
+    private String createURI(String accessToken, String refreshToken, Boolean isFirstLogin) {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("accessToken", accessToken);
+        queryParams.add("refreshToken", refreshToken);
+        queryParams.add("isFirstLogin", isFirstLogin.toString());
+
+        return UriComponentsBuilder
+                .newInstance()
+                .path("/oauth")
+                .queryParams(queryParams)
+                .build()
+                .toUri().toString();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,11 @@
+package com.gogoring.dongoorami.global.oauth2;
+
+import com.gogoring.dongoorami.member.domain.Member;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getName();
+    String getProfileImage();
+    Member toEntity();
+}

--- a/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
+++ b/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
@@ -1,0 +1,59 @@
+package com.gogoring.dongoorami.member.domain;
+
+import com.gogoring.dongoorami.global.common.BaseEntity;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<Role> roles;
+
+    private String name;
+
+    private String profileImage;
+
+    private String provider;
+
+    private String providerId;
+
+    private String gender;
+
+    private LocalDate birthDate;
+
+    private String introduction;
+
+    @Builder
+    public Member(String name, String profileImage, String provider, String providerId) {
+        this.name = name;
+        this.profileImage = profileImage;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.roles = new ArrayList<>() {{
+            add(Role.ROLE_MEMBER);
+        }};
+    }
+
+    public Member updateName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/member/domain/Role.java
+++ b/src/main/java/com/gogoring/dongoorami/member/domain/Role.java
@@ -1,0 +1,6 @@
+package com.gogoring.dongoorami.member.domain;
+
+public enum Role {
+    ROLE_MEMBER,
+    ROLE_ADMIN
+}

--- a/src/main/java/com/gogoring/dongoorami/member/repository/MemberRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.gogoring.dongoorami.member.repository;
+
+import com.gogoring.dongoorami.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByProviderIdAndIsActivatedIsTrue(String providerId);
+}

--- a/src/main/java/com/gogoring/dongoorami/member/repository/TokenRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/member/repository/TokenRepository.java
@@ -1,0 +1,30 @@
+package com.gogoring.dongoorami.member.repository;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TokenRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String key, String value, Duration duration) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value, duration);
+    }
+
+    public String findByKey(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteByKey(String key) {
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
소셜 로그인 중 카카오 로그인 구현하였습니다.

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- "/oauth2/authorization/kakao"를 통해 카카오 로그인을 진행합니다.
- 로그인 성공 시 accessToken, refreshToken을 생성합니다.
  -  refreshToken은 redis로 저장 및 관리됩니다.
- 로그인 성공 시 accessToken, refreshToken, isFirstLogin 값을 쿼리 파라미터로 둔 주소로 리다이렉트합니다. (OAuth2LoginSuccessHandler 참고)
  - isFirstLogin은 회원가입 시 추가로 입력해야하는 정보(성별, 생년월일, 한줄소개)가 작성된 회원인지 여부를 나타냅니다.
  - 로그인 성공과 동시에 3가지 값을 프론트에 전달할 수 있는 방법이라고 생각하여 구현한 방식입니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
- 노션에 application.yml 코드 업로드해두었습니다.
- 패키지가 크게 jwt, oauth2로 나뉩니다. 소셜 로그인을 진행하더라도 권한 처리가 필요하기 때문에 그 부분은 jwt로 처리하여 관련 코드들 jwt 패키지에 들어있고, 소셜 로그인 관련 코드들은 oauth2 패키지에 있습니다.
- 현재 로그인 성공 시 리다이렉트되는 주소를 임의로 설정해두었습니다. 추후 소셜 로그인 구현 완료 후 담당 프론트 팀원과 협의 하에 수정하겠습니다.
- Member, BaseEntity를 임의로 생성하였습니다. 
  - Member는 당장 로그인에 필요하다고 여겨지는 부분들 위주로 간단히 구현되어있습니다.
  - BaseEntity는 일단 제가 주로 사용하는 필드들로 넣어두었는데, 확인 후 이대로 가도 괜찮을지 피드백 부탁드립니다~
- 아직 예외처리 부분 협의하지 않아 일단 모두 IllegalArgumentException으로 처리하였습니다. 월요일에 이 부분 이야기해보면 좋을 것 같습니다!