### PR TITLE
feat #21: 동행구인글 수정, 삭제 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -130,6 +130,7 @@ include::{snippets}/AccompanyControllerTest/getAccompanyComments/path-parameters
 
 .Response
 include::{snippets}/AccompanyControllerTest/getAccompanyComments/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyComments/response-fields.adoc[]
 
 === 동행 구인 게시글 수정
 
@@ -142,3 +143,11 @@ include::{snippets}/AccompanyControllerTest/updateAccompanyPost/path-parameters.
 .Response
 include::{snippets}/AccompanyControllerTest/updateAccompanyPost/http-response.adoc[]
 
+=== 동행 구인 게시글 삭제
+
+.Request
+include::{snippets}/AccompanyControllerTest/deleteAccompanyPost/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/deleteAccompanyPost/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/deleteAccompanyPost/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -70,6 +70,7 @@ include::{snippets}/MemberControllerTest/getMember/response-fields.adoc[]
 
 == 동행 API
 === 동행 구인 게시글 작성
+
 .Request
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/http-request.adoc[]
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/form-parameters.adoc[]
@@ -129,4 +130,15 @@ include::{snippets}/AccompanyControllerTest/getAccompanyComments/path-parameters
 
 .Response
 include::{snippets}/AccompanyControllerTest/getAccompanyComments/http-response.adoc[]
-include::{snippets}/AccompanyControllerTest/getAccompanyComments/response-fields.adoc[]
+
+=== 동행 구인 게시글 수정
+
+.Request
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/form-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/request-parts.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/http-response.adoc[]
+

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -21,4 +21,6 @@ public interface AccompanyService {
 
     void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId,
             Long accompanyPostId);
+
+    void deleteAccompanyPost(Long memberId, Long accompanyPostId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -18,4 +18,7 @@ public interface AccompanyService {
             AccompanyCommentRequest accompanyCommentRequest, Long memberId);
 
     AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId);
+
+    void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId,
+            Long accompanyPostId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -127,4 +127,23 @@ public class AccompanyServiceImpl implements AccompanyService {
         s3ImageUtil.deleteObjects(accompanyPost.getImages(), ImageType.ACCOMPANY_POST);
         accompanyPost.update(accompanyPostRequest.toEntity(member, imageUrls));
     }
+
+    @Transactional
+    @Override
+    public void deleteAccompanyPost(Long memberId, Long accompanyPostId) {
+        AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
+                        accompanyPostId)
+                .orElseThrow(() -> new AccompanyPostNotFoundException(
+                        AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
+        checkMemberIsWriter(accompanyPost, memberId);
+        accompanyPost.getAccompanyComments().forEach(BaseEntity::updateIsActivatedFalse);
+        accompanyPost.updateIsActivatedFalse();
+    }
+
+    private void checkMemberIsWriter(AccompanyPost accompanyPost, Long memberId) {
+        if (accompanyPost.getMember().getId() != memberId) {
+            throw new OnlyWriterCanModifyException(AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND);
+        }
+    }
+
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -20,10 +20,8 @@ import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.exception.MemberErrorCode;
 import com.gogoring.dongoorami.member.exception.MemberNotFoundException;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -37,22 +35,13 @@ public class AccompanyServiceImpl implements AccompanyService {
     private final AccompanyCommentRepository accompanyCommentRepository;
     private final MemberRepository memberRepository;
     private final S3ImageUtil s3ImageUtil;
-    @Value("${cloud.aws.s3.default-image-url}")
-    private String defaultImageUrl;
 
     @Override
     public Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        List<String> imageUrls = new ArrayList<>();
-        if (accompanyPostRequest.getImages().isEmpty() || accompanyPostRequest.getImages().get(0)
-                .isEmpty()) {
-            imageUrls.add(defaultImageUrl);
-        } else {
-            accompanyPostRequest.getImages().stream()
-                    .map(image -> imageUrls.add(
-                            s3ImageUtil.putObject(image, ImageType.ACCOMPANY_POST)));
-        }
+        List<String> imageUrls = s3ImageUtil.putObjects(accompanyPostRequest.getImages(),
+                ImageType.ACCOMPANY_POST);
 
         return accompanyPostRepository.save(accompanyPostRequest.toEntity(member, imageUrls))
                 .getId();

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -11,7 +11,7 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
 import com.gogoring.dongoorami.accompany.dto.response.MemberInfo;
 import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
-import com.gogoring.dongoorami.accompany.exception.AccompanyNotFoundException;
+import com.gogoring.dongoorami.accompany.exception.AccompanyPostNotFoundException;
 import com.gogoring.dongoorami.accompany.repository.AccompanyCommentRepository;
 import com.gogoring.dongoorami.accompany.repository.AccompanyPostRepository;
 import com.gogoring.dongoorami.global.util.ImageType;
@@ -81,8 +81,8 @@ public class AccompanyServiceImpl implements AccompanyService {
     public AccompanyPostResponse getAccompanyPost(Long accompanyPostId) {
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
-                .orElseThrow(() -> new AccompanyNotFoundException(
-                        AccompanyErrorCode.ACCOMPANY_NOT_FOUND));
+                .orElseThrow(() -> new AccompanyPostNotFoundException(
+                        AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
         accompanyPost.increaseViewCount();
         return AccompanyPostResponse.of(accompanyPost,
                 MemberInfo.of(accompanyPost.getMember()));
@@ -95,8 +95,8 @@ public class AccompanyServiceImpl implements AccompanyService {
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
-                .orElseThrow(() -> new AccompanyNotFoundException(
-                        AccompanyErrorCode.ACCOMPANY_NOT_FOUND));
+                .orElseThrow(() -> new AccompanyPostNotFoundException(
+                        AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
         AccompanyComment accompanyComment = accompanyCommentRequest.toEntity(member);
         accompanyPost.addAccompanyComment(accompanyComment);
         accompanyCommentRepository.save(accompanyComment);
@@ -108,8 +108,8 @@ public class AccompanyServiceImpl implements AccompanyService {
     public AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId) {
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
-                .orElseThrow(() -> new AccompanyNotFoundException(
-                        AccompanyErrorCode.ACCOMPANY_NOT_FOUND));
+                .orElseThrow(() -> new AccompanyPostNotFoundException(
+                        AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
         List<AccompanyCommentInfo> accompanyCommentInfos = accompanyPost.getAccompanyComments()
                 .stream()
                 .filter(AccompanyComment::isActivated)

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -77,6 +77,22 @@ public class AccompanyPost extends BaseEntity {
         accompanyComment.setAccompanyPost(this);
     }
 
+    public void update(AccompanyPost accompanyPost) {
+        this.member = accompanyPost.member;
+        this.title = accompanyPost.title;
+        this.concertName = accompanyPost.concertName;
+        this.concertPlace = accompanyPost.concertPlace;
+        this.region = accompanyPost.region;
+        this.startAge = accompanyPost.startAge;
+        this.endAge = accompanyPost.endAge;
+        this.totalPeople = accompanyPost.totalPeople;
+        this.gender = accompanyPost.gender;
+        this.startDate = accompanyPost.startDate;
+        this.endDate = accompanyPost.endDate;
+        this.content = accompanyPost.content;
+        this.images = accompanyPost.images;
+    }
+
     public enum RecruitmentStatus {
         PROCEEDING("모집 중"), COMPLETED("모집 완료");
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -26,6 +26,8 @@ public class AccompanyPost extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private final RecruitmentStatus status = RecruitmentStatus.PROCEEDING;
+    @OneToMany(mappedBy = "accompanyPost")
+    private final List<AccompanyComment> accompanyComments = new ArrayList<>();
     private Long viewCount = 0L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,9 +45,6 @@ public class AccompanyPost extends BaseEntity {
     private LocalDate startDate;
     private LocalDate endDate;
     private String content;
-    @OneToMany(mappedBy = "accompanyPost")
-    private final List<AccompanyComment> accompanyComments = new ArrayList<>();
-
     @ElementCollection
     private List<String> images;
 
@@ -69,7 +68,7 @@ public class AccompanyPost extends BaseEntity {
     }
 
     public void increaseViewCount() {
-        this.viewCount ++;
+        this.viewCount++;
     }
 
     public void addAccompanyComment(AccompanyComment accompanyComment) {

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -77,7 +77,6 @@ public class AccompanyPost extends BaseEntity {
     }
 
     public void update(AccompanyPost accompanyPost) {
-        this.member = accompanyPost.member;
         this.title = accompanyPost.title;
         this.concertName = accompanyPost.concertName;
         this.concertPlace = accompanyPost.concertPlace;

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AccompanyErrorCode {
-    ACCOMPANY_NOT_FOUND("게시글이 존재하지 않습니다.");
+    ACCOMPANY_POST_NOT_FOUND("게시글이 존재하지 않습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AccompanyErrorCode {
-    ACCOMPANY_POST_NOT_FOUND("게시글이 존재하지 않습니다.");
+    ACCOMPANY_POST_NOT_FOUND("게시글이 존재하지 않습니다."),
+    ONLY_WRITER_CAN_MODIFY("게시글의 작성자만 수정할 수 있습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.gogoring.dongoorami.accompany.exception;
 
 import com.gogoring.dongoorami.global.exception.ErrorResponse;
-import com.gogoring.dongoorami.member.exception.MemberNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,11 +11,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class AccompanyGlobalExceptionHandler {
 
-    @ExceptionHandler(AccompanyNotFoundException.class)
+    @ExceptionHandler(AccompanyPostNotFoundException.class)
     public ResponseEntity<ErrorResponse> catchAccompanyNotFoundException(
-            MemberNotFoundException e) {
+            AccompanyPostNotFoundException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(OnlyWriterCanModifyException.class)
+    public ResponseEntity<ErrorResponse> catchOnlyWriterCanModifyException(
+            OnlyWriterCanModifyException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyPostNotFoundException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyPostNotFoundException.java
@@ -3,11 +3,11 @@ package com.gogoring.dongoorami.accompany.exception;
 import lombok.Getter;
 
 @Getter
-public class AccompanyNotFoundException extends RuntimeException {
+public class AccompanyPostNotFoundException extends RuntimeException {
 
     private final String errorCode;
 
-    public AccompanyNotFoundException(AccompanyErrorCode errorCode) {
+    public AccompanyPostNotFoundException(AccompanyErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode.name();
     }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/OnlyWriterCanModifyException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/OnlyWriterCanModifyException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OnlyWriterCanModifyException extends RuntimeException {
+
+    private final String errorCode;
+
+    public OnlyWriterCanModifyException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -67,4 +67,14 @@ public class AccompanyController {
         return ResponseEntity.ok(accompanyService.getAccompanyComments(accompanyPostId));
     }
 
+    @PostMapping("/posts/{accompanyPostId}")
+    public ResponseEntity<Void> updateAccompanyPost(
+            @Valid AccompanyPostRequest accompanyPostRequest,
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        accompanyService.updateAccompanyPost(accompanyPostRequest, customUserDetails.getId(),
+                accompanyPostId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -74,6 +75,14 @@ public class AccompanyController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         accompanyService.updateAccompanyPost(accompanyPostRequest, customUserDetails.getId(),
                 accompanyPostId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/posts/{accompanyPostId}")
+    public ResponseEntity<Void> deleteAccompanyPost(
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        accompanyService.deleteAccompanyPost(customUserDetails.getId(), accompanyPostId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/gogoring/dongoorami/global/util/S3ImageUtil.java
+++ b/src/main/java/com/gogoring/dongoorami/global/util/S3ImageUtil.java
@@ -8,6 +8,7 @@ import com.gogoring.dongoorami.global.exception.FailFileUploadException;
 import com.gogoring.dongoorami.global.exception.GlobalErrorCode;
 import com.gogoring.dongoorami.global.exception.InvalidFileExtensionException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +26,9 @@ public class S3ImageUtil {
     private final AmazonS3 amazonS3;
 
     private final List<String> allowedExtensions = Arrays.asList("jpg", "png", "jpeg");
+
+    @Value("${cloud.aws.s3.default-image-url}")
+    private String defaultImageUrl;
 
     @Value("${cloud.aws.s3.bucket}/")
     private String bucket;
@@ -49,6 +53,18 @@ public class S3ImageUtil {
         }
 
         return amazonS3.getUrl(bucket + imageType.getName(), s3Filename).toString();
+    }
+
+    public List<String> putObjects(List<MultipartFile> multipartFiles, ImageType imageType) {
+        List<String> imageUrls = new ArrayList<>();
+        if (multipartFiles.isEmpty() || multipartFiles.get(0).isEmpty()) {
+            imageUrls.add(defaultImageUrl);
+        } else {
+            multipartFiles.forEach(
+                    multipartFile -> imageUrls.add(putObject(multipartFile, imageType)));
+        }
+
+        return imageUrls;
     }
 
     public void deleteObject(String originImageUrl, ImageType imageType) {

--- a/src/main/java/com/gogoring/dongoorami/global/util/S3ImageUtil.java
+++ b/src/main/java/com/gogoring/dongoorami/global/util/S3ImageUtil.java
@@ -72,6 +72,12 @@ public class S3ImageUtil {
         amazonS3.deleteObject(bucket + imageType.getName(), filename);
     }
 
+    public void deleteObjects(List<String> originImageUrls, ImageType imageType) {
+        if (originImageUrls.size() != 1 || !originImageUrls.get(0).equals(defaultImageUrl)) {
+            originImageUrls.forEach(originImageUrl -> deleteObject(originImageUrl, imageType));
+        }
+    }
+
     private void validateFileExtension(String originalFilename) {
         String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1)
                 .toLowerCase();

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -129,8 +129,8 @@ class AccompanyControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 multipart("/api/v1/accompany/posts")
-                        .file("images", accompanyPostRequest.getImages().get(0).getBytes())
-                        .file("images", accompanyPostRequest.getImages().get(1).getBytes())
+                        .file((MockMultipartFile) accompanyPostRequest.getImages().get(0))
+                        .file((MockMultipartFile) accompanyPostRequest.getImages().get(1))
                         .param("concertName", accompanyPostRequest.getConcertName())
                         .param("concertPlace", accompanyPostRequest.getConcertPlace())
                         .param("startDate", accompanyPostRequest.getStartDate().toString())
@@ -491,6 +491,7 @@ class AccompanyControllerTest {
                 member.getRoles());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
                 createAccompanyPosts(member, 1)).get(0);
+        List<MultipartFile> mockMultipartFiles = createMockMultipartFiles(2);
         AccompanyPostRequest accompanyPostRequest = AccompanyPostRequest.builder()
                 .concertName("2024 SG워너비 콘서트 : 우리의 노래")
                 .concertPlace("KSPO DOME")
@@ -509,8 +510,8 @@ class AccompanyControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 multipart("/api/v1/accompany/posts/{accompanyPostId}", accompanyPost.getId())
-                        .file("images", accompanyPostRequest.getImages().get(0).getBytes())
-                        .file("images", accompanyPostRequest.getImages().get(1).getBytes())
+                        .file((MockMultipartFile) accompanyPostRequest.getImages().get(0))
+                        .file((MockMultipartFile) accompanyPostRequest.getImages().get(1))
                         .param("concertName", accompanyPostRequest.getConcertName())
                         .param("concertPlace", accompanyPostRequest.getConcertPlace())
                         .param("startDate", accompanyPostRequest.getStartDate().toString())
@@ -613,7 +614,7 @@ class AccompanyControllerTest {
     private List<MultipartFile> createMockMultipartFiles(int size) throws Exception {
         List<MultipartFile> images = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            images.add(new MockMultipartFile("image", "김영한.JPG",
+            images.add(new MockMultipartFile("images", "김영한.JPG",
                     MediaType.MULTIPART_FORM_DATA_VALUE,
                     new FileInputStream("src/test/resources/김영한.JPG")));
         }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolving #21

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
동행구인글 수정, 삭제 api를 구현하였습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
수정  및 삭제 구현에 따라, 동행 글 반환 시 수정 및 삭제 가능여부 제공이 필요해보여 추후에 추가해두겠습니다!