### PR TITLE
feat #24: 회원 정보 조회/수정 api 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -21,6 +21,15 @@ include::{snippets}/MemberControllerTest/reissueToken/request-fields.adoc[]
 include::{snippets}/MemberControllerTest/reissueToken/http-response.adoc[]
 include::{snippets}/MemberControllerTest/reissueToken/response-fields.adoc[]
 
+=== 최초 회원가입 시 성별, 생년월일 저장
+
+.Request
+include::{snippets}/MemberControllerTest/signup/http-request.adoc[]
+include::{snippets}/MemberControllerTest/signup/request-fields.adoc[]
+
+.Response
+include::{snippets}/MemberControllerTest/signup/http-response.adoc[]
+
 === 로그아웃
 
 .Request
@@ -49,7 +58,7 @@ include::{snippets}/MemberControllerTest/updateProfileImage/http-request.adoc[]
 include::{snippets}/MemberControllerTest/updateProfileImage/http-response.adoc[]
 include::{snippets}/MemberControllerTest/updateProfileImage/response-fields.adoc[]
 
-=== 프로필 정보 수정
+=== 프로필 정보(닉네임, 한줄소개) 수정
 
 .Request
 include::{snippets}/MemberControllerTest/updateMember/http-request.adoc[]

--- a/src/main/java/com/gogoring/dongoorami/member/application/MemberService.java
+++ b/src/main/java/com/gogoring/dongoorami/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.gogoring.dongoorami.member.application;
 
 import com.gogoring.dongoorami.member.dto.request.MemberLogoutAndQuitRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberReissueRequest;
+import com.gogoring.dongoorami.member.dto.request.MemberSignupRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberUpdateRequest;
 import com.gogoring.dongoorami.member.dto.response.MemberInfoResponse;
 import com.gogoring.dongoorami.member.dto.response.MemberUpdateProfileImageResponse;
@@ -11,6 +12,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface MemberService {
 
     TokenDto reissueToken(MemberReissueRequest memberReissueRequest);
+
+    void signup(MemberSignupRequest memberSignUpRequest, Long memberId);
 
     void logout(MemberLogoutAndQuitRequest memberLogoutAndQuitRequest);
 

--- a/src/main/java/com/gogoring/dongoorami/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/member/application/MemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.gogoring.dongoorami.global.util.S3ImageUtil;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.dto.request.MemberLogoutAndQuitRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberReissueRequest;
+import com.gogoring.dongoorami.member.dto.request.MemberSignupRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberUpdateRequest;
 import com.gogoring.dongoorami.member.dto.response.MemberInfoResponse;
 import com.gogoring.dongoorami.member.dto.response.MemberUpdateProfileImageResponse;
@@ -48,6 +49,15 @@ public class MemberServiceImpl implements MemberService {
         String refreshToken = tokenProvider.createRefreshToken(member.getProviderId());
 
         return TokenDto.of(accessToken, refreshToken);
+    }
+
+    @Transactional
+    @Override
+    public void signup(MemberSignupRequest memberSignUpRequest, Long memberId) {
+        Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+        member.updateGenderAndBirthDate(memberSignUpRequest.getGender(),
+                memberSignUpRequest.getBirthDate());
     }
 
     @Override
@@ -93,7 +103,7 @@ public class MemberServiceImpl implements MemberService {
     public MemberInfoResponse updateMember(MemberUpdateRequest memberUpdateRequest, Long memberId) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        member.updateInfo(memberUpdateRequest.getGender(), memberUpdateRequest.getBirthDate(),
+        member.updateNameAndIntroduction(memberUpdateRequest.getName(),
                 memberUpdateRequest.getIntroduction());
 
         return MemberInfoResponse.of(member);

--- a/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
+++ b/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.gogoring.dongoorami.member.domain;
 
 import com.gogoring.dongoorami.global.common.BaseEntity;
+import com.gogoring.dongoorami.member.exception.AlreadySignUpException;
+import com.gogoring.dongoorami.member.exception.MemberErrorCode;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -80,9 +82,20 @@ public class Member extends BaseEntity {
         this.profileImage = profileImage;
     }
 
-    public void updateInfo(String gender, LocalDate birthDate, String introduction) {
+    public void updateGenderAndBirthDate(String gender, LocalDate birthDate) {
+        checkGenderAndBirthDateIsNull();
         this.gender = gender;
         this.birthDate = birthDate;
+    }
+
+    public void updateNameAndIntroduction(String name, String introduction) {
+        this.name = name;
         this.introduction = introduction;
+    }
+
+    private void checkGenderAndBirthDateIsNull() {
+        if (gender != null || birthDate != null) {
+            throw new AlreadySignUpException(MemberErrorCode.ALREADY_SIGN_UP);
+        }
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
+++ b/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
@@ -43,6 +43,8 @@ public class Member extends BaseEntity {
 
     private String introduction;
 
+    private Integer manner;
+
     @Builder
     public Member(String name, String profileImage, String provider, String providerId) {
         this.name = name;
@@ -52,6 +54,7 @@ public class Member extends BaseEntity {
         this.roles = new ArrayList<>() {{
             add(Role.ROLE_MEMBER);
         }};
+        this.manner = 0;
     }
 
     public List<GrantedAuthority> getRoles() {

--- a/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberSignupRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberSignupRequest.java
@@ -1,0 +1,16 @@
+package com.gogoring.dongoorami.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class MemberSignupRequest {
+
+    @NotBlank(message = "성별은 공백일 수 없습니다.")
+    private String gender;
+
+    @NotNull(message = "생년월일은 공백일 수 없습니다.")
+    private LocalDate birthDate;
+}

--- a/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberUpdateRequest.java
@@ -1,18 +1,13 @@
 package com.gogoring.dongoorami.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter
 public class MemberUpdateRequest {
 
-    @NotBlank(message = "성별은 공백일 수 없습니다.")
-    private String gender;
-
-    @NotNull(message = "생년월일은 공백일 수 없습니다.")
-    private LocalDate birthDate;
+    @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+    private String name;
 
     @NotBlank(message = "소개는 공백일 수 없습니다.")
     private String introduction;

--- a/src/main/java/com/gogoring/dongoorami/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/member/dto/response/MemberInfoResponse.java
@@ -17,14 +17,17 @@ public class MemberInfoResponse {
 
     private final String introduction;
 
+    private final Integer manner;
+
     @Builder
     public MemberInfoResponse(String name, String profileImage, String gender, Integer age,
-            String introduction) {
+            String introduction, Integer manner) {
         this.name = name;
         this.profileImage = profileImage;
         this.gender = gender;
         this.age = age;
         this.introduction = introduction;
+        this.manner = manner;
     }
 
     public static MemberInfoResponse of(Member member) {
@@ -34,6 +37,7 @@ public class MemberInfoResponse {
                 .gender(member.getGender())
                 .age(member.getAge())
                 .introduction(member.getIntroduction())
+                .manner(member.getManner())
                 .build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/member/exception/AlreadySignUpException.java
+++ b/src/main/java/com/gogoring/dongoorami/member/exception/AlreadySignUpException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlreadySignUpException extends RuntimeException {
+
+    private final String errorCode;
+
+    public AlreadySignUpException(MemberErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/member/exception/MemberErrorCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberErrorCode {
     MEMBER_NOT_FOUND("회원이 존재하지 않습니다."),
+    ALREADY_SIGN_UP("이미 기본 정보가 등록된 회원입니다."),
     INVALID_REFRESH_TOKEN("refresh token이 이미 만료되었거나 올바르지 않습니다.");
 
     private final String message;

--- a/src/main/java/com/gogoring/dongoorami/member/exception/MemberGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/member/exception/MemberGlobalExceptionHandler.java
@@ -18,6 +18,13 @@ public class MemberGlobalExceptionHandler {
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
 
+    @ExceptionHandler(AlreadySignUpException.class)
+    public ResponseEntity<ErrorResponse> catchAlreadySignUpException(AlreadySignUpException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
     @ExceptionHandler(InvalidRefreshTokenException.class)
     public ResponseEntity<ErrorResponse> catchInvalidRefreshTokenException(
             InvalidRefreshTokenException e) {

--- a/src/main/java/com/gogoring/dongoorami/member/presentation/MemberController.java
+++ b/src/main/java/com/gogoring/dongoorami/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import com.gogoring.dongoorami.member.application.MemberService;
 import com.gogoring.dongoorami.member.dto.request.MemberLogoutAndQuitRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberReissueRequest;
+import com.gogoring.dongoorami.member.dto.request.MemberSignupRequest;
 import com.gogoring.dongoorami.member.dto.request.MemberUpdateRequest;
 import com.gogoring.dongoorami.member.dto.response.MemberInfoResponse;
 import com.gogoring.dongoorami.member.dto.response.MemberUpdateProfileImageResponse;
@@ -33,6 +34,13 @@ public class MemberController {
     public ResponseEntity<TokenDto> reissueToken(
             @Valid @RequestBody MemberReissueRequest memberReissueRequest) {
         return ResponseEntity.ok(memberService.reissueToken(memberReissueRequest));
+    }
+
+    @PatchMapping("/members/signUp")
+    public ResponseEntity<Void> signup(@Valid @RequestBody MemberSignupRequest memberSignUpRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        memberService.signup(memberSignUpRequest, customUserDetails.getId());
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/members/logout")

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -452,6 +452,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_토큰_재발급">토큰 재발급</a></li>
 <li><a href="#_로그아웃">로그아웃</a></li>
 <li><a href="#_회원_탈퇴">회원 탈퇴</a></li>
+<li><a href="#_프로필_이미지_수정">프로필 이미지 수정</a></li>
+<li><a href="#_프로필_정보_수정">프로필 정보 수정</a></li>
+<li><a href="#_프로필_정보_조회">프로필 정보 조회</a></li>
+</ul>
+</li>
+<li><a href="#_동행_api">동행 API</a>
+<ul class="sectlevel2">
+<li><a href="#_동행_구인_게시글_작성">동행 구인 게시글 작성</a></li>
+<li><a href="#_동행_구인_게시글_목록_조회무한_스크롤">동행 구인 게시글 목록 조회(무한 스크롤)</a></li>
 </ul>
 </li>
 </ul>
@@ -472,7 +481,7 @@ Content-Length: 148
 Host: localhost:8080
 
 {
-  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDkwODU5MzB9.Vy1cfCyMGkgqTmvzzJwyobtW2yV9R9uaTFEaNi72xhA"
+  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDk2MDY4NjR9.PCOmnnTCRyBynC7MR0arVL9Is9WZkfl9rXQ2WbZv1Os"
 }</code></pre>
 </div>
 </div>
@@ -514,8 +523,8 @@ X-Frame-Options: DENY
 Content-Length: 337
 
 {
-  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NDg0NzMwfQ.PeiyBfQ9zIejirF6TGT37mm8rDRghYmjWLamnEXW4xg",
-  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDkwODU5MzB9.Vy1cfCyMGkgqTmvzzJwyobtW2yV9R9uaTFEaNi72xhA"
+  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjY0fQ.MQE7P3AGNmkukrUE5TdVBAqrEOLNzX59QyDdFkhTR6E",
+  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDk2MDY4NjR9.PCOmnnTCRyBynC7MR0arVL9Is9WZkfl9rXQ2WbZv1Os"
 }</code></pre>
 </div>
 </div>
@@ -553,13 +562,13 @@ Content-Length: 337
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NDg0NzI5fQ.zEeeUOR14pJ7cqovzPyFRRiOaWErvGZ4Agp8s3vHfLI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYzfQ.Ql6Yz4F9iCl7JTQ3mqsKkRaw_qXA5m9GBh1OY4nPVOo
 Content-Length: 337
 Host: localhost:8080
 
 {
-  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NDg0NzI5fQ.zEeeUOR14pJ7cqovzPyFRRiOaWErvGZ4Agp8s3vHfLI",
-  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDkwODU5Mjl9.ydKmQkz5n5ORUBd1TH5LZ_61qfgTAJVGyUVuc172M94"
+  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYzfQ.Ql6Yz4F9iCl7JTQ3mqsKkRaw_qXA5m9GBh1OY4nPVOo",
+  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDk2MDY4NjN9.jwhhrRb8abiphqBXv9pqIm6an8Msw-HkVkWmSujyRWA"
 }</code></pre>
 </div>
 </div>
@@ -610,15 +619,15 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="title">Request</div>
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members/quit HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/members HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NDg0NzI2fQ.hhK4pXH84KWTLrXHg12Imuh-sL8chNl5wz58eBbjvwA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYzfQ.Ql6Yz4F9iCl7JTQ3mqsKkRaw_qXA5m9GBh1OY4nPVOo
 Content-Length: 337
 Host: localhost:8080
 
 {
-  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA4NDg0NzI2fQ.hhK4pXH84KWTLrXHg12Imuh-sL8chNl5wz58eBbjvwA",
-  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDkwODU5MjZ9.vSHEsdaTNYnkZPywJN2OQ8VXmAOwnExol0nHpg9BcAg"
+  "accessToken" : "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYzfQ.Ql6Yz4F9iCl7JTQ3mqsKkRaw_qXA5m9GBh1OY4nPVOo",
+  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJleHAiOjE3MDk2MDY4NjN9.jwhhrRb8abiphqBXv9pqIm6an8Msw-HkVkWmSujyRWA"
 }</code></pre>
 </div>
 </div>
@@ -664,13 +673,826 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_프로필_이미지_수정"><a class="link" href="#_프로필_이미지_수정">프로필 이미지 수정</a></h3>
+<div class="sect3">
+<h4 id="_이미지_예시가_들어가있어_request_부분이_복잡한데_이름을_image로_둔_multipartform_data_넣으시면_됩니다"><a class="link" href="#_이미지_예시가_들어가있어_request_부분이_복잡한데_이름을_image로_둔_multipartform_data_넣으시면_됩니다">이미지 예시가 들어가있어 request 부분이 복잡한데 이름을 image로 둔 multipart/form-data 넣으시면 됩니다</a></h4>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members/profile-image HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYyfQ.3UidL8yCacUSPuDdAdshdsH-GVXfO5e-yxWn-b-rbI4
+Host: localhost:8080
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=image; filename=김영한.JPG
+Content-Type: multipart/form-data
+
+���� JFIF  x x  �� �Exif  MM *    �i            �       P�       d��    98  ��    98      2023:09:22 02:17:15 2023:09:22 02:17:15   ���http://ns.adobe.com/xap/1.0/ &lt;?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?&gt;
+&lt;x:xmpmeta xmlns:x="adobe:ns:meta/"&gt;&lt;rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"&gt;&lt;rdf:Description rdf:about="uuid:faf5bdd5-ba3d-11da-ad31-d33d75182f1b" xmlns:xmp="http://ns.adobe.com/xap/1.0/"&gt;&lt;xmp:CreateDate&gt;2023-09-22T02:17:15.980&lt;/xmp:CreateDate&gt;&lt;/rdf:Description&gt;&lt;/rdf:RDF&gt;&lt;/x:xmpmeta&gt;
+&lt;?xpacket end='w'?&gt;�� C �� C��  � �" ��           
+�� �   } !1AQa"q2���#B��R��$3br�
+%&amp;'()*456789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz���������������������������������������������������������������������������        
+�� �  w !1AQaq"2�B����	#3R�br�
+$4�%�&amp;'()*56789:CDEFGHIJSTUVWXYZcdefghijstuvwxyz��������������������������������������������������������������������������   ? ��4� �o��7�8j�~1�`x��^!��MkK��Qѥ�67v��)�t[�;T����X/��#-���9-�� � �&gt;u^I��8����;��k-�ž&amp;k;KrQ10ԅ�i�{.U���[s��G�X|�B������v�����Y�0$^!��ʩ�6����	�0O�׊���j�$�x�N
+r���M��Z��r(�����֣�y�B��_gV������������}��?�i�7��P�ǀ4o
+|����ݾ�o6��Z�k:����+��Ӄj���N*]�.Yl)V�F|6� �[[�)����	����V��k��G���rۅ���1,%�6�1V�0����F��fH��Sӯ�¡v�7&amp;�Q����O��{�/:�ܟ7�~��V��q��sS�&amp;P������=O�/�j�/�)UJ3���]�QQ�n�~k��?��?�F� �&gt;'�~�w�r�Q���+�)��s]�iWL�[����L����+p�b��t9���� �^��}����(x���v���&gt;�q��=R���W��y�c�%�L,���&amp;M^��X$���-m��Krn"��~-���=�]7�_�_��?Ϯk�b����^�U��(��,?����`�,;I��0�p��Q�Es�)Js�jj�L&lt;=�)ǲ�X�V����Fc�`?��r�������Q�G�ǖx�|ɯz� w��u&gt;��Ɨa�xCQ�O���6h���13��w\�`�,��~Ƃ?��&amp;��A�Tm��8�G�=k�/�Wԛ��8�e_��8���"'�x?E�n���^�Z���\%/Mk���&gt;�êqX,da��b&amp;�w��&gt;��_#���e�� �o&amp;{�����%��~��?	]��qϙ����c��� ,_�1��sፉ�?hl��$�mT)��Vs�������m_���x]����X���|1?͝�n�� +���C�@x{��&amp;�I�gY�$���+����_*��}9�*��V�}�b/`����_k_3�����?�Ox�R�~ �O�;K����n�Y,-\$��nWGʪ�ݸ��J��f�_]�럳��GqoOqq�����J3��:�1����H;1�j�&lt;�k_�R�Ʃv.�8�)�GiO9������8�VFw�g��bF�v*���4}s��h�Ohڷ��!��6����ze���iW3��֗��?�4d4Rl�)���l|i�;�TT�
+�i�������d��˫�+�a���O�#���
+�{B�r�����wo�OD������*7���ْ�,-&lt;3�"���,�a� �3���1�@Ц��i�~�^�w�6��]&amp;+��
+�A��YwnU�y����k���z���&amp;��p$�Es	o�����9���ږ�߲w�,bu�����?h��J��ۤ.RM��젆��X����3�(´?�J�z����{���McjQ�_ާ,==Eo�I?�	7��3���c��/~)|2�I�mu'��w�*[�$� ��xeGm���p��Z�'�׆u?�#���=����k���,c��M�R��+ ��Bř�-�B��G��������V���A�� [�V}$���
+_I%�����y�+w���F�U�+������u�Z3㇄e�]J�)q�d�*�X�\\��od~l��Z6ѽ��Vn��c�D�up�(b�֯V0�5�1Jp�����l���V݈�Q���8�T�F��uT�D�*��ok=צ��8�����ſ � �	���?&amp;���#���2]�&amp;�O!�s�B��#���k��ڦI����2�];|�|M���:���}����"�3�� �U���&gt;�]�:,�k�f���S2	��nnLBc��(� 9���mo�4�؏�$�(���|1��i�f�)tI��F��
+.[!~\n$��x|[��1�&lt;s���S�� �ӄg9I&amp;����k�z���G��g9�OV���J�B�(r�S�R3�,y�����L�Z������i�&lt;:dm���q�@��W�Sc�*�un� �����:֕�85�1gp`ե�5��%ki�ö��7#Fn7m���޿ֿ���(,&lt;Ab�d�$�[���c�������ğ�/񞇯��K���ӵkh�Q4ӇO�Ƭ�v�I۠�����L���8ژ|6�Y#���#F��+��筹��[S���:_G�U
+��)O��Ej�V�m�����+R��ϱ��t�[j�Nw@��b܏���������|&amp;ntvw��B"q�yۛ&gt;�&amp;=����*[]���[�P�YG�H�h�+xB����x�+��#�������&lt;�iM��6�[���0 .U���"s��l���&lt;��K�a3%�RU兛�i��%8]�o�%u�+v[/��.7�SX\UC�(Bj���y���ee{;+���?��&amp;m���tn�����≳���.��l�ֿH?i����� o���/�z.����d��wic�+KK�?�G��� �Y!y�&amp;r��]y*W�t� �3'�o�#��WdK='Ŗ����� 	N�I�ߞ����� �&gt;,�|� n��.�ƚ=?R��kK�hdh�s�/:L쌯�DM�p2Fk�x�۬�1��ƽ&gt;�ZW���NmIrөJQ�n[7	��i���&lt;+��a[���qT�|EF�&lt;�B�U��9:5/J���i�Z��~�����ä|/��?�/�&lt;%�Go�X�Ei�&gt;�J�֐5��I����0-�^s�w���P�{��]��/k�B�&amp;���Wb����8�	C��#�����h��&lt;1���y2����j
+�9|�dGBT�ˑ��oǍ&gt;�\��u��my`F��LQC�/3w,��!�x�	'�SZx� p�g5ZNs�z�����9M���k�i�j��}�స�Y~2��a����N�XΚ��3�O�FN�;��y$�ڊG�� �F+������Ӓ&gt;z� ��0s�=�8��-ո}GF��?h�S�e��Xa!��ެ�돘���N��������/yd{m	 �F=R&lt;[������q��u��ݽ�v�7��~b�YcW	$sH�3".O�^��&lt;}�8� �nY?��QV�� �4u�o�'��%C����vTs|��ev&amp;�{�̩^�/k��� l�"�����i;��w�$�&lt;�Wo�m]'O��_�O6&gt;�Dǹ�s��#�v��u�"H'Gޘ�%�Q������'8��Bն��k��8;�1��\I~�&gt;��nܗ���9����V�w�X}�Gcc�H&lt;�S33�b�� ��9�۹Pk �iV���Ym���1&amp;�pA#���sE}B�出���W��B��x4�+j���}�~g�?�n����熠�&lt;o�MY�Y]�.�`]ل�l����l��|��������ĳx�ᇈ����gu}f�`����������&lt;����ē��I��Y,��=7;{w�z��Nk�� �C��'�n�ISε�2��G�d('W�����|]��he9f+��'
+uUXʻ���o�F� �n�~��O�yg	�f9n;0楘b){����|D=�f�'~Oi;t}�^l�X�S����#�8���w�[��o��z���~���^6A��?�w��u���N�}[ �1����}�w�~�����7�qk�ח����[�[�����&lt;һ��Z�y�L��N�o�pa��Q�s3����ǿھl�C�j~�?�χ�-��E������kF{K��/��V	L�[L&lt;��H��K�Q8E%����t�ɣ]	&amp;L}�l7?�{{�?ҿ��6t��ǩwGT�T�p�7���Nqӊ���T�ʞ7��bj&lt;-J�*�*5=�|����������&gt;�"ȡı���׭J�$��Q��r��~8ϫѫy����O۫�t�����&lt;f�!�ڋ׵���#�R����Юő�N�pk����L xOB���.~��_�_�J���Ѻ���?�
+�N��˿�&gt;������?���|+�d}.������X�UeJhF49�y[��I�V��岶�m�e��&gt;C���i��խZ5�Nu�7&gt;i����B�����k�� ix����n�$�H��g�{��a�K�0���W�P�&lt;�?��4Q��,}G��؏ӎ����-��C�?��&lt;?}&amp;F��|B�x����x~�,����ہ�qֿ��K�����o�-ٌ���Mф�YW�]C#rQ�=1׽~���1�� ˨��\�4�����5g�ب�q�]��0=:jSw��í��9��&gt;#��� &gt;��[����7�� m��M���[]ϣY�g�Ma����..n%��8�/�,��+�?��_��h?���}��8��~����T�����H�y&gt;ZʱG��*�*����[��&amp;x���|ۭB�&gt;��������ʗK��^Zn�8�U�0�(V6��� Ҿ�&gt;x?K�Z����GS��趢��-��ǠZ]�̟�wV��yFI��/J���@�qʟkW+��?/�a���8|��LF"�OeO:�yʝ(9:P�O�h����nѷ�&gt;$����Y�&gt;4�9�^��_�uq��#	A?����m��[�O�&gt;��o����.�R��q��q�I���*,Rޥӡ�i�k��,�8`ZLB~��� h-[^�tG�[=;B���i��®-U&lt;�(�^i������]�..&amp;�L�1�#�7[���k{��d�	��5����/�Wַ�j���~�~�{�k��m��"x�A���e���g^r�D��Mۭ�=����ܬ�-��b�)K���I&lt;�q+�.=�a�x2��J��.eR�Nk]F-�|+�k����X�������T�}����}�嵾g��&lt;t��}�iRj�0��v�eu�M՚i7�g=�2���B�2[2�V�Kk�3~Ӳ����OsfQ"�}2���iL�M�LU]|�.�����%����w͓|���w�����MOT�#���v�J��p����]� b���,͑&lt;�{y-e���������b�������!,��#�\F�e���s�N*)*Q�K[��Y� �=Ӥ�*����4�|�J˗[u�嵏�o���� ������i�hz��� �n��_^Z�x�L�S����[y,���&lt;k��pvy7&amp;�l&lt;5� W�ď���o���N�׮�a����/��#YIa��v��Ƒqo��~/�qma{ϝ[k�pi�6*�چ��	..����묢�I��[	��$ڴl��g�I(x�M������4����+߈�����/�N���/�e��R���侵�2�Ώ=ͬ� f��J����K�K�i������p�px�Jt��J���H�3�8���_��%���k�9n7��X\�+�UL%Xզ�G���l�8_��g}5џ��o/��O�ړB֬��uk�Q���Z;��T��%����)s�� ��X��W
+����Fv���	� �s� ���7����[�]h�6�,t�s�0BN����V���e6��}����d��wm&lt;�:qi�+�����N���t;�u6�G�����g�����[�'�T&amp;9tx�EX�G	Ο�O8�&lt;J��b��yV{���ʱ�� yN����aka�t���R��Sm�8N�)B���� ������\��O���2�NV�*ӣ��S�k���hʍT�ڜ'ua:q��
+�h&lt;%��,c��C��@�bѺ�a�����~i��w��O�Wb��=����+�mK(K&lt;��v�L���/ſkZ/�5yuM*�MY�5�Km-�[t�$,��r{�~tx�������`�MM�Ŵ�5�q��$�*�#� �:�Y�A����D�&amp;�o�MUU�XS�3g:X�S�V��tܜ��N7Nɿ�n��j�p��F^�'�e�Ԕ�ן-���m�?�A_�^%��������.�}��#�Z��y&gt;���x��4��,�f�;�'��O�)���/�*��O�|E�%߅t�+��궳��� �s�)o���T����T�i����o���� ������_�z���;x�� oC�g���� ���G����Ү�����e��	�E3x��{ٸ;QFK�:����O�&gt;7,����l��T�ƜeE&lt;}a�I5�5~d������ �\��x�NS��3��)Ɲj�|R�N2�7��+W��ی�G�O���iW&gt; x2oE�7�0�'����]�A�XE�ޠ��e���� 5`�&lt;��6/������|X�|7�j7����4&gt;�'Ȍ��1顜4UT]��� ��_��������v�^H&gt;xNh.lTl�&amp;��VC���#pA����?o|�_��Q1uݡ\��U��B�U��K���~&lt;W~,�eta��5q:
+2t�i�IՌj7*T�{���-�v�'��g4�$ҕ�&gt;�9��R�=\5x������$�)���^���l�3�O��|��+��|���xv{�.��v_&gt;hc�wG�j�y�f!�cU8݁���IZ�(­��}m�#� ~D}d��X��i\�uI�1�e�݂���=p:U�6B��x3K!�^8�q�u'�&gt;دr&gt;ʝ=*j�N��?���o����b1�n+��Iխ��V�J���֭7V��� �RnV����2~�?�Z��c�g�q�����	[�'��]��%��˩�;O�nV�&amp;�:��$� ȶ��
+x�?ڷ��j��_	��j	o��h��`Ku���N�e��es������� �A|)�?�G������Z7��Ow��W)����C)y�D��������?������3��ܟ&lt;*�1�&gt;��1��ۥp�U�7�h�r��:����]��z��n������a�*��u�T�[Z��IB�&lt;��NhB�9ҽ�ީ+X���p�m��ngL���$�G���L��&amp;Ʀ2��ܕ���:�{��ahBW�4 �ow*m��m���ǉ� �����.|O{�^��� kxE��4� �\�g/�y�k�O�� �U���&amp;�� �s�Z����r�]���ٞ�ۧ�."�K}�����&gt;S�$�c���$(6�g�+��z��Oΐ�8�`I���yvv�q�,q�G\@k��og�֯��J1���u'|�7�A����t�&gt;����N+;�&lt;z�ԫWz(T�*����;v�^]vm;A�Z���q�9��F?���0�|H�ѐ�
+!�۲{c�}}:u5�g�+o� �*?�✿&lt;?���?�O�� �|Q-���mk{�����,���&lt;��y.� ��y�W�����m/��=z�x�@վ![Okw��&gt;9����n�ib�F?��9~��[�W��{�_�&gt;1���܆Ie��d�J۰U� ��ҿ|ÿ�s��3��Z�~�Is�"ߠ��?Ͽz��q���l��I������{��$�6z_0�&lt;Q^��%j+k%}u�� ß��b��߳�����u�z�Q���I�=N�9��&lt;S����|k��w(ےO��?�&gt; 	��R:/9�1tç=q�n�������Ӥ�������'�q����F�2)T*T�pp�q��iH�3kypۼ%��=�������p�+��4���E,T�F�xV��r�&gt;�PJӂ�-�r�����&lt;�=���x�ҩJT��*�����r;'	=���w���μs�9�t������a��3�k�i�����ou[I��o0 ��B����S�� /�I��o�+�`MK�-5��&gt;"���&amp;���[�V��]
+]�nM��}�������oٮ�S���x�ėV������. �-\�����"y�#��GGB	����*����p1�0� ى���l��8ҮQB�/��14��j��U���%�{i̕�u&gt;+1�n���O*�/��B����j��:��e9$�+F2v��O�'���������C�S�]oE�-ݭ���&gt;��ǥŭkR�� a����6Vv����K,i$vB�&amp;��������W�� O�ȼ�� iw��&lt;C���_���q�����}6i��RX���6��\�6��S�I��mq�T�ʿ�w����ۛ��&amp;���O�5�
+[j:�����G�D�uK�4�Mw���ΟD�U�1��wT�y� �?�?&gt;�P��I��[�i|)����x[I������8�ۿ�˨\-���ng{xt�N��+�8!Y~�\Gp�lNm�b3,S�a�)N��zp�8C���6�n׳��~d���'�)�XZTi%���T�Q���*��]y�~�J�&amp;�iF6�)=m�w���&lt;Q�&amp;ӧ��=3\K�K����w,�����x%���$�08�{��P���j_��O���S�W	��L��w��&gt;U�x�F$���p�U�3C_���_���į�j�Яt���)�g��6�E�Z*���(�)_40�!6�7~���@?�����_|E{�0�����ޫ�j^����Й���$�v�$O5�ͳ�F� ��Ab�{���Ҟ�J�T����/i�iϭұ���(��8�4��� ����~�e)J�vw������_�����+�UHسmyZH�@��*��hꟼ#np��e�T�G�&amp;��G��,񻄞9:d��c;���0R��l�?����_��˫�{� �~,���-�/|!�5�Ce�\��ܴ��p���M���=� �_翊&gt;�p��&amp;�~�@��ӡ{�NMW���Ӭ�sM���wmilry�,P��'��D���f�,&gt;a���h&lt;UU�����3����z�f24��QP�JJ�W��UJo�\�~}��7���?l�d�VFk�DW�{�_t��f�,P_�4��B9��~Б���J��h.��X\i���L�́uE��4���=GO�y,�"��u��]���Z[|��;H��o�n�ty�Ő]�5��v�7	��buc��qE�&lt;*�A�v�u�i%��j#���c=���m���y�t�2\M�_��b�̸��U�	�E[x&gt;�VP��CGOiw�����C�p�ŸT��yZ�� ��׵Ϋ�VW��|?��ŦkV������ږ��k)1͸$��O��Nx&lt;��].a��� O��H���@��� |C���U�/����{Ks��� o�EʙLBݥ״��m��i���#��a_�T�k���K%�ƭ�}F{B�� ����3� i�Д�Dz���s"[d� ��[�w��#�/����?	~*|����`|U�.�������sw�[�\�����r�ixo-5*���D�I y��1�2�3�je����xZ����jT*BO���M¦�ԥV��?2���S,���e7��pu�����f��P�l���S�&lt;�6|���㿆�x�D�е���i�:m�&lt;0����3��pT�S򴁏�|թ~�~Լ#�?�3��M2=9�;{}�,p�Vyb򼇕T��`��Nb�φ��t�Q-o`]N��PX.$t��[�#�m�#'�w��9�'c�S�b���o ���7q$��N?Ƽ~���=��dY�,���nNU1�����?�Ъ��iˑ{5kݷ���8��7�s�+)������n匝�wk%����qa��#��O؇����-�o�&gt;:��D�����x�-t�/��Q���X�#$�*=��񳂠�#�� lo�&amp;烿k_�S������_�ί�SÚhzU��&amp;�����������[���PC�{�I�]��V&lt;u�cQ🉬&lt;c�x�[��K�����OC,r{�0`@�N��!��!������6/�_�ږ��֘���l��63;�k��wv�g*�*A|Y�i..����[��%f^҃�,$b��\� W\��ۥ�������p�����j�*���W�剜��&amp;�]ԅ�e*s�6�D��/�G�Ť|��}��]��k�S�0xJ���(�����y�,+/�&amp;;HiLay����y��ũ���$e5��24�$e��Tdr=��)�͛����������������/�x�U^"\A��iMMԞ�M.^T��j�����f�#�`�e�&gt;���PUcF�k���Y�'��i����]�y����?ؓ��&gt;ЁdC�Ƒ|Ķ�Edq�k�j����ŕ��v/�	�7�p	�9�+ӿ�[x_ 8���&gt;¢o��#N����s[��jҌ3ܹ����;7˭�{�M�o��� 2L��-�7���t�G�'�B�~�П~"�z�|�G��O���� LѮ����[��xb�].��%/��͖͝� ���i��O�_|#�Ht{���t�Ay4�H����%�&lt;P��(�q���}�
+�Ķ#���l}:sG�+�
+v�!�T�?�~2�h֗��I)F*��ATQRP^�%{Ez(�� ��=0����RS�X�j������ٷc����o��tA�Os
+#����.~� ?7nGpW�� º�m6N?����&lt;;���B�5J�Vr��x�iemvWZuL�(s��帊Pn�֌�og�9�����&gt;����z��]�}?�������z��]�}?���}�� ?�_x��/Oz;����� _Ƣ'&gt;�O|��)~�'?�Lz� ����������Go�����Ґ?��O� Z�o�޿w��{�(�?ğ�5.��z��s_� ����xSJ����H}{f�F�%?�R:��G���(��޿7�]��@��&gt;щ���@힞������s|��K���_��oÿ�g����a�����+�scI^3��� �k�+�&gt;|�Dm�|���QT�g��&gt;�qɿ�S��� Q��|��q������ ����� 0i���!���L&amp;�x�����s�_x{HךHn&gt;�+��	�$��)U�m]��� ���.��Y����Z����W[��8�������k�ۅ�ٰM�@H��TE�� ���5���b�g�&gt;��\�&lt;����X2�o�}#���o&gt;�,���c��:��s�H��17����n������*^��~�6�\^�!��A��𗉭&lt;M��:���	���X�ı�Z��&amp;��x�?�9�� �4�GX֭uh���}/Y�r�Vo��ҥ[O���b}�nI*h�\ԩB3�Y�Iӌ��_"�&gt;����\����kK����oe8J�J�[U*�.Zq�H�I�O��uk�3�?�+���;��4���5ɤ�M;þ��K��^Cu5����۾؊&lt;�Y!��捕�n}�M�H�����aG�����X��������,R�$�X
+��6�SC�,��b��� e��z7�d��­g�&amp;��Z��_�m|?��Vz�͆�~l��|s�YϨ�=6�*�v+�=��=�7�-��2|L��u���m�����jV�z��ƍ��âZ��_g]j�.�j�$m�e�
+O'ؙ�l���k]D��e���w�������¢�í[���qJ������~��cr�n��jK��8����X�Mݹ�F�&amp;�.�'Om.�o�!�$�v���Ѵ_�*��v��͘� 󞞃�����e��us��/A�m�VV�-��*2��r\[H�Dcd�O�ʦ$v?�Z_ď�(�� ����&lt;�&gt;4�Smே�1����ᰞ�]�߂�Gy��w���� Z����:V��KK_���)�Pn.����Z��	uɞ�����V�{=.�]��+��������S�5K+���q�U�LӴ� �Oѧ�n!���C���G��2���&lt;4(�VP�Q�n�:�q|-:7U)�7)s��K�_��f�fh�P�eٞ
+����f3��U0�n�*���EZ�$���J:{���&lt;��� � `�T�$����g�?�w�K�����M@��v�Wo�k�w!w�:f�*J���	��?̯����g���}�?�&gt;!����[Gյ/jmk�{imؼ�X�6ڂy
+����Cx"W�h�.Xy���?o�7�(����~��%�|��`���u���MZ�M�]=&amp;д�&gt;𶑫��������\�p��hZBc_2��|E�MJO���=�������"�R���#���_�m�d�_�&lt;w�_k�/z�!� �M��Zϡ�� kI��m�ܴ��v�w��Y�1�0�9��R�J�yC���\�ӧ�*J���V���rJ4|�k��?�p9.#	^����x�Д���as	T�R����J�%��Ӌ������k�^'�o���	���m��I�����K�5K{�%�"�`��g�[Mpt��n�"�q�Cٿa_�Z_��T����K��x����ox�Ñ�R{k;�I�}u��8��Xx���[�Sj��1�c&gt;O�'�xxO¿�xn����ľ���e�X�N��u=cV���^-ִ�1&amp;𾏭O(���5=,ti��䚼�����/�O������i��u��~�/��W6����\�����W����}O�lU���=M�{s=���8fz�cr�D*WJ��W����ٝ:5iU|Ϛ��UkNN���&gt;o-�V���f�G0��ٞ�b!�JQ�:��V����!W]o�_�W�E�xH�Q���h� ~ ���AZ$�$~x��&lt;������hG�&gt;*��O�2�7�d�폛{��x&gt;�g2A�z~�:����1}r=z=|,���6[߇kt� ��KO�I*��9�� �=N�����:~~�%�w}��� ��˻��9�v8�M�p
+(��
+*�v�������.!q��'F�Gz��&lt;��*b6w'9�����^7�+{�~Hn&gt;ҍ�i�f��v{8]� f��ǫ����a~տ���m���o���g�������O�g�4�O���Z-����K&lt;	,���N߼�H�@*�Fu��j��GNu*Ԓ��]��_���ft�*�UP��L]Jt�Þ�Z�K�Z���n�����&lt;N}z����Sk�O[��?�� 	�:��+�}� �O�&gt;*��մ~_�k��P��'��A�@7ۉ����96��H���gH���L���1��gm,�F���� ��.p3ǯ5~��&lt;&amp;&gt;�Ju���l�U�+�T&amp;�V-[F���M��n��E�U�U)T���EN�*:nѕ��\����g{��V�ݴ]�+;p���}�?α�Ě0Q#^ƨs�bv�S���`��;�|E���l�|c�[�#�.-n5{8�ao-�ׅ������^��&lt;/s��k�&gt;yJI2�����J�[ze%S�p��s���Y�l���E�WxT�9��kK޵��mc�ȰT�����K�J1�ѩ	�6��K����o�^^���:χn� �a���b�����z�T����|^�66�SK�x���~��W�j*�&amp;��X4��Ic��՞N��}z
+�����\�����OJ�Nv_)����q�8����ԫJ�/cN�((9��u'=\��n{+(���/�xO*�����VU=��I�+|��Y_ɾ���?D~��nx,���� �q��W�ז�.� �?���?��z�Hd�&amp;�� �	� ��Oű� � Zħ�3������~��~(��&lt;G����O������i����R}�k�3S�x�f(&amp;]2����2��~d|��|�������
+�� �����᷍M��q�Ϥ��F��$V������M�Xk�V6�������:�֞���V���/���/�f��f����~'�R^��U����m��:�Y{y�K�E,X��W�^$��|-�H-��M9Qm#c�[G�Ф�|�"�J]��E��ߍ���W�9��O���YN�����7�ST�J�O��"��T�Q��jqQz���/�����)�p�*ԩ��u|�,EJ���O��"�ڧ����B�
+���2p��t��-�~|;������~iz��Q�7m/N������P�W	lr�W17��R0|{�zg�,4��/���5������q��V�aյ��.��D���	�5-.}L�����ZiZm��	c�{⟊��i:��41�;��1R�'G�&gt;R�[��
+����g�4{���;�{m�KS���W�fTi�n����{ˉc�V�x⑞4X��&gt;�`(Ws�,Mj�')r��B��X��T!���-w� /#���?*�sV	��:j�i%��N���i��Ҟ�wV�����x/�x�~&amp;�����E��.lo��mCD�Lm&amp;�=]�W:���?h�U�l�����.�i7|[��èe�e�� �ٮt}����@�&lt;S���GGh�}V��z�凉N�������H�f� ��4�R��Q��to��� l?��~��/�+s�˧�r�Ž�0���	�8�/��h,��d W����	��E��~����id��UҵM%`�̿��o���]��2mHE�*fg_)Z0���#S�c���ҟ�����]�jU4�����_2�&gt;k�!�ԭغur�BO�؈ҧV�TQ�:���X^-J7���G��G�4-N��-Okw��|!�j伉����%��-ك�f���F	ܑ,~���;��þ9�Юt�x+H�
+xN�U�O�X׼K�鬭�O�i�f�=�E�4�4?�w&lt;Z���O���}-�Ϸ���O�K�����N�l�H���"�$2)[�%̊�W��W�t_�l~#�0Ee������F�C��@\�T*���4���'��^W�����k���og+{Ej4�C�K�JuV�%�7��yvgMѧ^�N8�(S�T%�,�y�wt�^���z�W�ψ�uφ����Ώ�4��u��)������ϖnhm`wL�.Y�6r&lt;:�����o�:���m��&gt;�Uؾ��_hH�Tl�H���Gmaq2]��47fC��P\Ix��J��7,�O{u�����s#;*��F�bJ���� ��5�w�/�z�g�Z��]������#�����)/�]�����$���'�Ye����l�J̻������F�lE&lt;�\T��_��R��N��A��u7=�ϧ��XH&lt;V2o,^ak8f(b����	c0��I�F��r�u�I�ɧ�����X���K�^4�O��SI���I/짚�yQ�C���W�ח��8�u���^$��^��$����٣���;G&amp;02��r+���,W����c9&lt;u��Nx�'ds���S�0��J�*b#��	N����d�'m_��Q&lt;+����MG��Us�Φ]F�wGS)ai҅��q��mf����)� ~���b�&amp;���j�l	�������Am-�)q��e"&amp;p͸t V��~��&gt;O����b�mKM�ݿ�.�l�.�c���V�",��
+�8 �����?�Q���U��F���u;�5.�KK��u���[D|���Q�&lt;��Ǌ�|���e\w�b�(�l��r�*�t�[��'�-"������ɿw(�kc�[FNT93_�P����x���٫���2������V�����_񧂲��r9�T�򧈥-w�M�A���^JI&lt;�$�0vH��%��8�8�&gt;���I���	[s��g#�g��?���Vu��:�
+8:Y}XGZ�mW	s'R��R��¹c�k_�wV&gt;_2�)�(��C*���R�c��E�A�Ƣ�?j��_,-���i�n9�}�������X�B�� sԄV��x�9ʾ�v�om�s��ZK=�&amp;X�-�\��0�D�K&amp;FHRy���bcM�j*B�J����#ݫ���5��B&lt;�\�S�EJ�6��v��w�����^���~��M:��_�u��+$���YL�Aey�w�]�B��H �뗷���f�s��o' ��q��ڹ��:��W�ӌ#��U�.�V��l�X,G&lt;!��z�P���敖�k{^�̞����+��Q���Z}��ٙ����63�aN̬Yw�����@�Q�8�F���{����U˱t�*s�iE�������O���'���V?c߆����V�\_yFi��Y�A쿼vbv��i�\s���L�&lt;i� |��u{�uo��_�Z�����4-6�Z�����.C&gt;ۉb�x� #G,�-�_ԏ�[Yӯf��:K�����$����3��P���e'��ߜ?�L/���������w� ��|��3tom�ժ�&lt;��#���#߶)��F��Y�VgZ��|B�9C���ӝ��J����mk5��o~��T��q�	rYƣ^�U:y�^�;��}-kI~ݚ�����?l��$�|%w�_	Z�Y�{f�ϩ��I5�T�����U	�
+��o�5�M"�1$x$����0�� O~��_�U�o㧁� i=
+��V��KM�D:�6�H�M:��]n�d�U�����$�m�,X�F�B���6���kk?�n��QA�j�V���%o��'��S��e6Ћ]�}2��,�I�q���p�}|8�-���9��{VSKB���MƤ񘅈�9�U�5I�i�n�4�x����9�������J�8��!
+X�aU�t�S�Rn*�9��yIs�}C� ��&gt;k^8��h=SZ�=��&lt;7�j��J��S��C�I�����&amp;FXQfa� ��MZ�{o�~�հ���xuCd�����IY#�Wp���~��{|��Ə���L|c�G��]��W�Z&gt;��GV�\���X�� Xr�s&lt;��D�$LQ�����i���/i���{t&lt;;��Kd��X!2�u�!����x�W���N�yA����x�&gt;��m��&gt;ς�x\e�:�O��
+8�o�KZ���[iuʯk�aߙ7�e��X��hѳ� �c�N+ï��sWnB� �-�����FO�{f��X�KvЕ�e�m�ȌpA�c$c�=s���&gt;+�z����z� �tǧ�*�~�ˊ��=�kI�� �~����Q�ߙ�4��55��_�}��~��4	wa�B*��3�s���῏x��~8�Z;���f�յArI�{�(@�,7e��������?����� ���~�U��u�+%Ǝ�N�z���ϕq}aq,%�G�ˎ��{�0�|Q/�uM� m~� �����g����7��&lt;�TG����S� P ��㪸&lt;	exZ�n�\UgN����j%{�M�W�V{�����^c�]�?7�S�bqpY]9b�b�8�V�*���A�,=�7�7;I+6��O�&lt;5�x���������.,���]dM7T�-�bI�d@�2mHdX��HW�?�:M�í/B{�����-�g�r�Y��|���i�p���$j�����g��_���αq�\��h$��$M�啈\s��85�|5������z��ﯖ:�� ɛM���#�]�ڪ��H�/��&lt;�푾�$�з�w�V��؜�	����1nW�
+P�o}��KǗ�n�n��XJ�N�V���{l7Tq5��V�75� /UF�N&lt;��k8�˯��-�^0�'�� �e�NM,!��/�0Ǩ�
+����n.-U��V0�+@%C����������4vM&gt;�	,4��P6�-iaE�B����Y�T��z�4��AgyrD�1mE�6������ ���������Y����3������˩M�]Q���u�t��k�eV�ly�q�H����U��Q�N�y�ޛ�:\� ���\�潯�����x֔oR�i�Q^Ί���qi��vW������߳�����S&lt;����m�ʰ,DL˪�h��y����)����~8~�Z&amp;�iki��tHV3$gP�cm:R��	&gt;פ^_y�B��yg�c
+��M��a{��� YA�]��+��wA#�\IZ�v�y�?���ҽ�O�W���0[��	|	q{jM�w�^�e��\���/'�hM��s���L�_zY�AF�W�.�i�
+Tm��f��n�5�px_aNu��p��N�&amp;�ck){N[ݻ�mU���׾���iZ��o��5m&gt;��c�49ɹ��$���D�ʥ����$b�|��𧇞�Y�Y��Ux�v̅��@���*��3�ē�V����=�����yAR;{U�$����Fq���*�T�ދ��vPƗ`�%��]�[��p��(9# ����q�9�����9w�j��^�}_3ʝJ��NR�K�J�����n���J�/��[�CM��e]B��S�XJ���:|���աe�W�����EK���b�v��e"v��@Ӽy�h�!�NC�/ym�!Aax�`Ŧi�:,��E�������ݤ��hEx���U��hO �ַ����0���6��.�Ol�����'�5-wL�&amp;��6�m����3F�41M��P����m��_�^��9����y�P���*P����Nhԝi�Z�j��tU�d�Ec�ێ8��V��X:
+8�L6a���XzX�ʕxS�w����*�U��'�+�_I:���}�v���8�=k���Zc,���?3`�x����{g��a_����u�F3�q��O�j����M�*T?�t�#�r��:s�A渊�(F2�ך�����ԗG{yZ����p�E������s|˖o�W���F~U~�ڬ��E&gt;i��`��)�ZgX�F�[��I^r@����O5��^�G� ��|�l&lt;Q��BK/�8�:Ύc�$:�1&lt;rÂ�m�U��{�!�?��x�_�o� H�v�x3�|�� �*]1�� ��|,��V��~�ūA��S?�|0��~�O,��_{�W��*R�V��jC꜍��)W��� n�U����u��Q���|%9a�K0�^�JR�*��9G�Ҕ*���5��}#����_�u+����_]X_�\˦�Ϧ���Z���h�Q�� �k��IO�i�V��!��0zgdj��=v��8���蚦��E��Gks�x��#1B���[�v�T����'
+2_w$c�4XKhٸ�l�~�� ���ckc����˞���.XF���؄{�o��? ��K��,�V�14�J�����Mk��M[��-o���!狯�s�Ӭ���Pc�L���~k���ƛ�7�R�v���,��Ю|��{��a&lt;=iy,D�ӧڧY��&gt;eC���t{�[ksJ���&gt;�pG��~\������l���/��������}�ī�9'��-�������ms�0f`&lt;ॲ���hq8)Q��5^��T�����=�N���(o%%g��&amp;N�M��),;�sZJ�J�� �ל�����s?���� �4վ!�2񕧇ﴏ��&gt;�,&gt;/�|�n5=KXY��nl��V�i訲�L�7A	_��w�0�_�ڷP�z��g	��i����S�t˩����;v��?�&amp;߇���k��g���ŝ}a��Q$�F���B��/�+c#���BHf�&gt;���e��WNѭ&lt;3�Z�6׾$�-q�6�e��E=ͨU�q::«t$H�1ۆ��&lt;&amp;ř�.�R�P����B�yiGG�x��=9�ԕ�ѭٷ���ɰ15j֩Z��
+�IsK�V��=�AC[��O�Դ�0�,Z�&amp;�u���\I�IiBU���U#q�I9��|g�-�:�WZ~�v,l�}&amp;&amp;Ӭno�"����&amp;khܫ����@#1�J�yn&amp;��X�ݜS_x�����J�)ƣ^ѻZ�//^������ g�x?�o���8�O�����vg]4,�����Ѷ�7S�3� ��|_� �� ��=+O����m���֧��;�W\`#��,
+�՞I/��ehŌk"�5���.��K��|+�'��ۗ��A�1]=�A#���8������ m��~,�۞8��#��|S�t�7S����_�(L�\Z��i��%Y#_3�r
+�de�ssΜ�:��"R���ܧ�nMv����-^Y/�U�(T&lt;����ͯ���^Ӵ�_�x�&amp;+y���Lw)4�*�dKű�&lt;���r�c�w�:��tO�#O��v�E��$׵�-���ԭ��NƊ�������@��2�nw���?���b��ǟ���� ٵ-'@𕗄�5��z�K��c+�g�B����\��٧�?٧¾*� �L�~5��1�j���q�f�lmu+(4�1Ok��,V�)Z8&lt;�Yv�u|��+��xT�ֳj5)No�5iC	B���m��K]��|\�2�ˀ|˲�n[���pFe֖{)`q��*��CBMՆ&amp;�"r�X�U��N&gt;˒���� �~��_�I]&gt;��\��4kk���Ky�$٣�*�k�;�Q*x�s�5�5|J���
+�D��/��׈��m,��[�o���I�2�dLp��,@�˯�G&gt;�e� ��y=��ߍ���"�9a�⽭�G�p����,�ͱBr��w�����$��͞�s�5�������Ik��۬�6�7�@��d�X�)ݻ���1���Mi%V�N׵�.�|�m�i{��-n����������U�x�I��5�H��e�����΀&amp;q� y"i9�;/O�#���� ��:��;��i�}y���Z��?RmW�o�od�g��Pi��2� l��rOp��?3�`C d4�&gt;-k��xoJf� ���׿׾ ��w�����V��~�����_��%� �Zn��7n�G�p&gt;C��!���zr23�k�M���ΏɹK��4�ɳkDA�*�y�S��3�Y� �ZcY?಺K�P�y��3�s������8�=;� m� �"�	�~��F��a�ڕϛ��	B�r3�����5٘���\��!�n�[mt��z��_�1V�?��J��T��T���xL���nnow]�n�/�|l�4�C&lt;~v�z]ۃ�Y�V^���G��/��~�-����r�K;��Z[Kأb�kr���*�[����G��c�h&gt;!vO,�nu����g�:w�3ֽ_�1��"��η:�����O���/�rl=n������W�5xN��������ݿ�sZ�pه��9R�J��*�|��V�4��^�o{�k���+I�����_�&gt;��C!��w,,um8��N���0��YJ0����Yޥ��7E��z���_j�˻o�Q���*�ڿyC�Cm$���_�����O��v+�&lt;ɩxB|O�_��;�(��#՞��{6�%ĳ���\�XE��#�g����G��@��׬��Sĳ��p*oDO3u������*0���x�v����z��l.��0��&amp;���J�JOV�{*��T������_���Γ���U�+�ܧ	S���GV���o$��N�?U��_ [Jc�ZHF�$M���|�|�AT�
+�tz��&gt;Cmآ�I@#G��J���+�  Un�
+�+���|q��n��u�b�,B�
+�b��u�|��N&gt;l�cN��ǯ\#�Dz}����K$�����.�q�����T���%L�QvO�Ҋ]�uf������V���F����Ի���a-!e%i_g�u���q�⏆b��&lt;y�:.����cA#8O����x�YM'����I3�f�c?c�IP�;o9�$��݆�?-��7�̖������\&lt;��n�6[����`�,G8\����/�m~��"����KD���I\)��j��c|�"dd�8bUJ��|^:xYb�
+5�T�`�J6Kk�]���{�iS�z�)/����Kv�߳�5��� k�o�&amp;g콮~�^(�5��a���:���K���O��Aa�E�r}�QY&gt;�ڸ�X�ҮVh�{m�4�U�� �� ��� b� ���V��|A���W0à�oǐ����&lt;K�2â�4���d֮��"����|3��K��B���������/�5h?����� }@�6�mm5���h�.�O��f�Ԡ�n4�x�!i.Sh.���!� �?�M�� �ǆ�/���|3�x����E"��;[��-|�V������vۻ�����/�p���e,n^.Qn&gt;���O���=[I��ev"��_��Xʓ�����GܫRI��h���u����	n�o??8����#vs�w���_��w�X�����X������zW!����~*�O��|!xu
+�� �z����	��閺��p��.�*�2wAq���9;*(�4۔iB��n�u2
+ȍ�9Ǧ}���2Ғ�iG_?g�ᯝϛ���T�M��S�e'�������B�8��?�t�I��G�RN���\��Q��^·4��� �u"���%C�!�����^:V?�2��{�fH]'����B�l��^Xg����	��x ��"��V'=6k�*0��:��A��ſ�;� ���� *)m����|�� rےX�����~W���|7��:x�R��d�Q�q�2����Pq���EM$�Kr~���SO�on���?99�#*O�H�k�~�}o�۟�)#��b@�\�t���1�y *��&gt;Rq�����+q�'���Z[�m�doo�g�1�z�ȯ�&lt;6J�[��Q�_��Mm�r(�k}��-t?,�ʒu�Żʤ=�S�{����Iin��)9�/������Eoj�崆I5ň(@���4D� [y#�Ο�(��,�M]��l~|�w�$��p���?d�0���&amp;� W~$���?��C�¿|/yo�̭�*�-l�u��{��r��,Yq�2�lc�{� ��|c�� nYgo_A� ~|3���e�[=c[�FeYt��Mu3�-�W�;��|ᚼM��	S�,�+��8���,)�p&gt;��]�W��Z�\!�3N��x�����:��Jَ3�`�ҍ�&lt;f.��\���Z�B5'�9�g�����&lt;/�x#�T��j�"k7��Q�n$�T��Z�ܓ�k���d�iZ/�if`o=���Pf~?�~�s�&gt;^���q��E��0�V�`�4�xn�B��H�$h����(�r;��.���sR�1�]6�&lt;d����Kv�~]��O9�3��n��c1_ͦ'Z�5�~V�/euk+��0xe�`�x��0�z��ʕ8�nO]�K�ڻ��=�.�u9����\ֵw�+xZ�X//��I�`t&amp;2%�c}�#˚6b�C�S�����2����٦�R�,*���ZF��&amp;7NG �3E}&amp;��P�N��hGOi�.��&lt;yׄg%j�I�����o�&gt;�wi��쫦_�Z��&lt;�T.#_��e^w{���'�%��N��Yx�R�g��9���r�M���Ե-;G�����3G�L�����Ƃ@�����t���#�i��S�q���� �/Eu��=���~?����2=;�w��
+��q������7Q���&amp;��TiḔ���i$�^6L�!��;�v����&gt;X�WzEZ��T��� �|�uo����l�[ө���sAS�k|w��s�?�)�	�x��{�#�7����2���Eњ�Uմ�u=&gt;���T��U��{�Z�#��#nq�8��G�w��R���^j�6v��n�\��j���H��H첍����u�� �]oK����a�Li�����+H-�[�B�*�ʐ7���E~|@���R��i�׾+���擢4�~d�m�x�TĢ!)H���]�&amp;�����-�\׊���e^3XN*�a04aN�:t0�p�ӣ��u\\�����?��&amp;]õ2L&amp;��*�9J�.�J�*T�bj�P�i��Z����]�g��)����	5��W�f_\|x�`�B�����ۨ1�y,�%p�����o������߄���'u��qq���� d.7v��p2#�T�ڍ�z߲�����j��o�&amp;� �?�+�4"�����	$���떄jpDR�9%��k2�����|a�.����׆/#��Bi,�m��ҽ����I�ݓ	b7�J6����ӱ�T)�*E��K&amp;����ӳ}����~[��*���҅EI�5���#���Y��������Z�)7v�Z�W*H `bB�L��D����|����*NTxOJm������x?�z����X����[_�Zēη2y�m,7��(x�n*T��V�+���'V&lt;B�ؖ𦔧&lt;���`{{������� �[��o
+� �S�� �8��ն���%� �W����"�n鎡�����T) `��&lt;���� h� ���mg����$���H$O��������o�*�s� ��Wvo&gt;@�O�C�s�pGN3_ۇ�9?��M�&amp;��8���1�c'�~�Տ�͌�/y�dXk�|�޺�|��Ԝ~�^$E+ӟ���KZ9j���������,���F.�:��.Ny�� N��?/`�i� $�� Mo��r��^/&amp;���x���gv��@�����^kؾ\�'���Wv�� ˛���3�?�|W��;��:�m��7���O���Zբ�ň��mWO�}��7]���C�x�k[OA��J�Z���!���ml.&amp;��o���QYCb�]I,��A�X�Fq��Gs�O�_��^ �WT���4�&lt;E�x@m�ݣ��-�^YH�{;��ug*��.D�M���(��� ��~�z��?�&amp;���=A��|e����-*�"VU���_��`2����Ig]����v0�� ��}����-|I�)�ߵ߈?g_���iP��d�|?��o�Y�������Z,EJZX6�j�e�P*�5������v5ѫ�u��B0S�����V������%���lNQ)r��aiU����aj9�O���&lt;Dot�O�G���
+jך��[����e�]�!��!�ƪO'�\�/�Q��@��&amp;d��q���Ju�C���}G��z3ky-,/dRJ�L�݀�q8ݼ}�5FR��х��k�B� m��y���%hacld�*���m}�����%�k�
+Q�Iԧ�-���o�{�;+���� bӫ���U�qR��N���V��M�Z�w½/E���/6�4��]� ��tUh�W��I�#�lS�o��6�I�l���LI򀼑����.+��93�l�4������&lt;�f�j���4��1���~�� ��O�4K�:��k��:=�֡��]O0[YZD��]�;��+xQ��i�4�,�Mt���Z�)Q�Z�eB\�jM�%��-4��&gt;g2�)Ƥ�T�aN.nRv�b�y�z�u�3��+��߀?�?�5�J��=b�E��_GvT�[��M��Z����gh�1�h��k��w�ۿ�/j�Z�A��+*]�u2�Ʋ\�K�JaHv�Ʈ�4~[a�3��g�
+��y_~ڟ5W@���?�o��v��"k$�� ]�\���nH4x��b�G���PԢ���E��L�������$da�:�W�g��'S�8v�֗.g�7��G�����.J���җ&gt;��ƞ"q-&gt;$�f���9z��N6��ϕ���{����w?���"��#T�I{���R��?������_x�Vٮ|2��.�6��;IZ���Y�7W��o�������ws����؟��S���+��7q=���\E#Fl.��hPv�1���nP˚� &amp;x�X�u=/\�����k���Ф/=��ep�m�B�9�w������K�%I�x��b� �&lt;� ���3R�&gt;�پ ��m[V�6��� �M";[Q+6�����t��o��xF��T�C�9�E[o����&amp;�:�:n	����9;�҄~�v���/w}&gt;c.̣J���j�o�F��{Gw�U���c����d� ����6�&gt;�]&amp;P�K�_x2C���0�g����$��&gt;1�-�
+� 6~l����7&lt;e &lt;�s���i��� �߳��Oh~7�o���_�c��o��4=KKԯ�+gl������msi5�嫬W�}ҵ��3/�_fxaA���.0W�G������:�玕���p�G�iҫNT����f�%�R�5������ߥ�� \ɧ�~���R&gt;��� �ܣ���dҿu���/�:�|3�-N��&amp;�&amp;��K�̢r��w�S�0r�"h��^5��x�_	����Ow���ʆ4��pN�gk�y)8#צA��	I��ÞwX\�8�d�O�#ߊ�;�x�-�S��I����k�_]�W�6�&amp;��_����	1���~?Q�:���P�j��"jj�r�WW�ۭ^���~a�Px����Zmw�U��[E�۷�wF?�N�.�ӕa�υ%0k�)��v�kyk�6Z���ǐnO�I��~��Y�5���t� �B��$���������8a�5[�m��̂�k�y����������O��4�2����C��2�KלdHW�A���� �|/� 	7���+�v����-tx/`���=b�X�V'l�F66lP1wō�~���/�t�J�����Yu_�&lt;_T���q깔�Ҷ��J��?�&gt;���?�p��J�O?�A.h��RX�s��s:U'}�#V�����P��f��h�u+�Q��V�l�h#)��B�E�rJ� �|w;O���&gt;bu�i�wg1=�r��l�R˞q�5���cmVX�T�m�h66��B��;���S��2q�/�x���QI|M�K�85]r`#�l f&lt;��FўJ��r?����p������M���b�Q�r�n����}��F.��o��mL"C=��0K&amp;�� ��rG! �M��&amp;��z~�c�I=�E$�����N	�};��8l��&amp;�+Ju/?�vi.�ʺw�?&gt;�x��]����n�&amp;���HS�VQ{sZ���ӧ�/��׿g�7C�f�7��ӚE@Y&gt;٧�j��%.�s�PCk��?�E���4���1|B�}c�7^0���/����΍Ut4����8TiY¨AɯнL
+�9	夲�#�q���q�q������~�N�,��@�?v=�� :�L[�͊�jJ��)�����������E5yE˖[Z�����t?�Z��ǿ���W5���P�����+�N����Z5����G����X4�{�7Ȋ���ILp���Al�%y6_0~Ŀ�W�&lt;u�_�H��|Y�|3�F����� D�X%p�Ռ+(M�0�Sld�a� ���y-�c��i&amp;Ӭ�j�m"�&gt;dqj���?U�&lt;��@8�~� �b��Q�5k��;��O|9�ž�	A�Eiig���k�nq�W���v����f,����7���
+������%ݪT�y䟽�ǻ�f��ξ븊����p�&lt;&lt;�5)�O����[w}n�?
+� g[�l&amp;�&amp;�k&lt;�i���/�{-3O��o��,#�&amp;gnV5�ܸݒ�����(�.&lt;�*)f�m��K�)���n����L��)�\ ʂ9����=x�K����#,����~��	5�bۺG��,�&amp;����F:py���_��A��i�K�������F��սx��Ϊ��ӚU��˗{.ݺ���L�S^�����\��!�l�(�׶��K����u[oi����]p��q~��0�f`�ZG��z
+�k�-�^S�^��}3w���׵{��x��L��Inw��!��A�/񓎟����c��H�������=�������)��4d��K^�z]���f��a�&amp;��T�Q�5�T��}�	?�U�|� �otX�͸�5q�:JN1��㯿J��a&amp;�ͪ �2��:�$��?6 �����Ukk����x��r;�U@�N�׎F2=����5�;F�Qi�5�[�CM$�ԯ�F���[L�B�;�1��3]J��a���ۙ{O��J�LEId�Zp�(�T���\���� 3�{ �}�S�T����qNk��irJ?�\���MFM�ܶ�~��0y�����|K��1�8P�ye%YO;�.+����o��|U�KǾ�{����ǌ|C�xz��a,��KԮ`:��(�Ec`.on$O*��Vo������ ����Z����2;{� CZ��_�Sc���kZ���i� �;�$���A&lt;R\x���Z������d:��R������&amp;�ǿ|e�;�����c���~ �,-n��$�֏s�\M��A,�m.��Gik&lt;�l!Afݿ��[��N�Ff��M�T ��NZn�g}-�^ϱ�vg�[O��`�N��R笔hF.�ꔹ�4�Mӹ�'� �� ������'��� ����o�uw[��}o&amp;�����?����V��ѯ"MY��*�� Tg�5�t��������yq�� ��s��
+G}�P�o��hφ�6�&lt;�-����&lt;+��A�$Xx�nR-]��H�+��I������R��1i��ϥ�[�t��p\%�F��$I�6�wFUB�@�&gt;j�S�m_���a�#���,�A���I%�ec�;˘��G�H�G��W*Kr��e4�7�e�����}zt���R�JN�{ʬ!&gt;�r+_����ZY�Y�թ�:y�'Z�zR��j��}�I��
+�.xs����%�����381HV2YI�ʬ��̥�?6k���Ɯ��ZGoQ��kƬ�O+�7�v��*Xnf��Oí�OH�m���G�i�\F�y/��ĈX	w��ՙUH �:W��_��X&amp;��gHl쬭�/5�&amp;[-���'����P������,�K�(�/#"q�{� cc�׫I���=۟��y�����]���.��Ov�')I��������?Gǉ4�Niod��4B�Ge\��B�C� '#�S��X?ಟ�S4��_���Mm� ��yl�2x�K�a�m����M��D[�`��2�U�!�@ۯ��� � ��j:���o�^"���94�|O�n$E6���\�������3��T���q?-����_cKnl�NCrw�I �?��U[/���."�㉄y��X�Г�1����I���u+A��JqR�� ��H�"�1br��hԽ&lt;~aE�3��ς�&gt;_~���M΍E��Rn2�($����|��@�#�E��2���u�j"#3�NP� ��c�`u|;/�,8�s��g�� �����l�f���|�&lt;�;T���&amp;��	�/�l�H� @�;�[����s+,��7݅V{�wG ��N�_��'������K�..�YT��Nf���Z;����-F�.ՔX�Wz&amp;Y԰�S]Tz����NH��2K�~pwfO�7m'T!Ou�K�66�V�j�q�F���&lt;�6rĜ�d��Ү�yѝ���x8&lt;��#� dd�qZ�|Ҕ�拍�m�K�&lt;����'ſٛǺ����Y���5}�麌�	���QMk�ZX�w��mBu���Z��mu[)�[�?��� �|� �@~~�?��|S�M��?��?&lt;G�=c�zΡ�����:���{�����㵺Qka�j�o|��+����mj�a�y�v�6v���~��q��
+�&lt;���1���6ΒG}�^O�|��S�n����a��QZ���o໰���o��nɸ�F�.���)(�ƄaDyZ�X���W��V/O��޿���?)�B���j������*r��wR�N��wv{/�hiL&gt;�w&lt;�.�S�8��c�3��_�� �L3�p���|��j�5���;����{F1&gt;q���n����/���!�o�h/����w���~1x*�H�L��=ByR�E/nml��[-����,ױj��Γmf��iڧ��&lt;1'��� ���?ሼ#}�kz�?�'ֵ\xkU�ԭ���gP�����-�̎x���H��b��g���\FO��xk2ɳ\-M7[��1���S�Ѩ�9F\�)��{N	^��m;}���_	rW�ISt*&gt;Z��J�����Q��{�O� ���&lt;sa��,7�=�{i�"6_�g��%v`̧7Z�g�����_�ǌ���xu	� �]�L���tk�6��&lt;6���- +�	��oگ�W���=��L�q�Ox��7��,o�/|=-��}Bh������3ƦB��D��D(Kt� ���m�c�'�φZ^�w����N�5����S�����k�ԷH��T�LVO.5@'��3�r� 1���[�s:��.e�Qxz���n�Вŵ��'Z�,5?i�-"��������~�1T �YgU�e�������*b#�p��J�w�����ݼ- �u}IT8�u�ሃ��X,Z|Ax8P��ˁ�n���漏O��P�g�4�D����k��� �1l[� d�� @-�)T�^���O Kt�{#&gt;3�C���~�����x��󌶫�mJ�7_�i�l  ��� �ɷ�A'/?�a��ҋz�
+-�v�{�q�����}�n^�#��&gt;$���,-vS��v�q���P�M�r���������q� j�����ok�o���O�ʍ&lt;Չ����`;pNB��0&lt;up;d��.Q��a�azԡU�NQ��e�V���V��O�*���A����Z��ʜg�x(BI{�g��?M�����H��
+h)c${��I�A��(T1�2�H��
+��M��*&lt;�_�������s_��ٿR�K�� ��L��F� �6�=�d����M��\s�qӾ*��h��]�ʍ��Nѷ8T*3�:t��5W�,�.�x�7��a�S�m��{=7V}{�1��^ʪ�&gt;W%���[�����c��� ��5Q�
+[�m�V�uO��D�w� gh���F@`^�?��~�?��ՠ�s�׏��?�|D���P�oS�MR�=V�)w���'Y�8��HS�7�2��� W?�P��s���QH~�|X�|A�X|-�;x�D�X��U}&gt;�O~�ۻMm��L�.&gt;}�[������E� �~8��?�o�:���-���I��!�����qan`h�w��5��G"�3-��ѥ
+��NT�U�LyFq�QN6���&amp;��~�e~α�j.5�ӂ��P�������]O����i���0�������t|$�?�߂vvwv�"���ͨ�� �6��_h�5x�y��\I2o_2$�)������hzc�lM"�j��&gt;E�X%��z�ϱ����B�ٿ�W�����ƫ�7�ߋ&lt;?�xf� Ǻ����&lt;3�Z��u�ht����H|햪d]�2�����Χ�m�� cö��e�.�F��b�22x�=��^!p�)$�8�.i7)�+��_#�b�?7/+M����&lt;�?g�j���W�5jx�3��{��[�+-mk\��P}�B�*��6`�u��?z���s�����&gt;ќ�A�n�$g��đ�pkܵ/_�P�T�Yö@	�,I�3��_���/�����i�
+�u���_���lou��e���MԮ�6�T����"�����5֚t:�ŋZjQ�_Y�e��K�����򼱕)�U�G��
+tl�5d�Խ�'*�:s�ۚ;����|)�bq��.�����S�4�R|��J�Ӟ�,9���~W��=� ���x�_�R?��:w�M^�&lt;a�i�v����u�Ω�8%�T��u�1X.��݃l�h�RmN�'�o�	���/�Y��%����5K�}�Zi�\\~��̱�a��bX�lT����#�`�/q�^6����w���5��Y&lt;�bt�Y�.��!H����RJFÿe�Ge����"ŀ.d9y0I��.0�������xw)�)a0�:0����0�5�օ9c�PP��^_�}��T���S��~A���#��8�a��#���j拇��+��V:~�/S
+���J�*��VP�nT�i4����F���C�k%[�2۝���ț���� �B�����W�C���4��=��3&amp;h�y�°Y3(@X�TH�p]�k�fkw�4����w)�"w�������$[5�{�����iVz��8����ⲒX�&amp;�+D&lt;�£Du,�|���e�J:_��O��)U�*1�奵�O��s��^�kg�-WT���١��s-�j����vvP�y��,��o��w����ײҴ��X�m�KK��WP��G��1ͻM�)-&amp;FS乖A��+o�Y���I���ڇ��C��+i�уZ薃+������ui������0@��i���n�X��2��E��21$�ܛP�1��|�]J��(FQ��.en{[T�Kw��]�&lt;����(ʢ���_�u�Eg��C��_�,ߎ���e��O��:��z���k�H���d�]܍��..5������%̚T�Mz�ڭ��6��� o�ڷ㕪�9���\xV��xWJ�t-��L$Bu+K���T{WQ�)u[���N^�h�c%y�ay�ItXZ���n�m�I'�.M��������Ui�{\���c�&gt;��@���b��@��{�bݰ ������W'�V�'��)�'_�.�p��U�w��9�{q�0\�w��O���Fy����b3\m\,)Ƅ��ޤ(T����\�J�J�}QZ����^W�=oF�y_
+���&amp;e���l�1��w��|�15�Y�@�+��B�S�!�E՝�����"�!�&lt;w�Ѽ'kg�����P�#���#�D��n�I6ѕS�5�Xx#K�ycTP�cǴF	q,�� �� z�aR7���o����ﯩ�F\��r�x��w�ZE�ws����ٯ�g�B�6�;�/� �7&lt;(u��m�y'��mN��+�|�h��V��	J�"8TIfvi#u��aEQ����e;y�������j-���I� 8���z֋��K����~�rK:�����$p���q\����I��@�S�r��{�b^A�'���c�~�1��s:����W9�K:�#-�����m"ly�K����~U&lt;��{z�t��&gt;Ի�Y98
+�{�#Z���R3�.V~�k���BA&lt;�~+�,��Dײ��X�I+��(���'���*�;qY�V�|�/$�%����2������*,A'Ԥ�P�4vI"�Ug�&gt;խ�{�+��ƍ�6�O?b�!���ey�#Ҭ��7�vVw�X�6o��]�_�v*�������L~ƿ4�|#���n�� ������*|0���4�y-u8R��Q�淺k��x�ò�y��7���:6�����~&gt;���r� E�@Xa�bH��
+��QQ����^:פ�&gt;*dث1Fp���0�Q�ꭁܩoS��r�R�x�ZR����������[U}���FQ�%������um�~Z3�C�d_�3�_���H����K�T��,t��m��?|C�ۛH�~Ϻ�T�obY'�׊���G��S�l�j6:����u�f2�z�� �q�_�4M�����P1?)X���8ݑ�t?���/�G��◅m{¨��w�_������_�ɨ�l&amp;U���&gt;Y�&lt;G�=^)`{Kد�۩'�5�V�������!���� �Gį��~�|=��|w�j�5Ժ^���KK�KO$�]��k��x.�K��K��!��TO�x����Z��ҥ����i�5*�Ӄ�W�^�M6�{���:8��2���_���S���Խ�F�S���׹�F�&lt;Zv��\�P�ZuǗ���#�� ?�&gt;���#ӝ����l�O�&lt;�rne��J��g�F-݉���&lt;K�X׼�iv�^������X,���O�-̅v��g1`3m
+s�A�~��wS�J��H�Z�R8ݬ%�ں.�	�_�]�.�E:�8�f4�M8W����d������p�8�g�������nn]m�Wm5Z����{��ǋ�)�)�Owl�������d���Q��Ӭe�%�����b	 �ph���ۯ�	�/��G��X�{�xKK_��7���#?��PE}/V�5iu��K�e3ܾ�֞F&lt;�(㒪�{8� �N'�C:Q�:4�B��U*t᤽�o��]�y7�9��V�Q�U����*b'��ӕG��J�oRm8BP������K�`��o��s�G�R��.�4�M�rXy�|ö8U�* c�Vz?�A]Q��-�zx�H��O6�A=F@�����Ӧ��ρ�:���&lt;�T6�����-�5#t�B�oP�10yMk���֝��� ۭ����j�����L���!�&gt;��C7A� ��u*+�U&gt;j�W4�a��:�f�Yփ��T�V�T~/1.P��ӣO�q��9B�(|u���Mi�)=-���%�Y���
+���ۨ�W�ik��if�ʚo�|$�q���́��]X0��H⾧�I�S�%���Ӽc��g�ޟuaw���u-��C$�mR4�Tp���c�=����V�Z�7���+M-n�nl��w&gt;X@ѱyc/���n�N0���������3�����cxۄFrG#'�+�W�L��E�8̎t)`q�}EG����	P�J���OO��k��ݟ�~fx�煲��Z�'��x�.&amp;�J�%_;*3�II�ih��V�;����9_�&gt;��=��1�ҡ�x C�}D/C���l~\�ˈm�V�� �sgws���8��9w֡��2�=���� �_�]���M|�w�&lt;C�+m[[����Ϻqg4���r�*4i�@Q��;� ��V��p|t� ���z͍�w~�ڿ���}�h�Mo@V͕��ּ^����x�y���a�����~���H?gO�~/�^=������^��6x�_k�I�v�7��WL�p|�y[�+�������z�4��qo�$���|�N�L9m���K���w�^����9c�g�i_�Ԇ+���[��j1��#�oq��0Lge��cq��kѠ�m�J� +u)�z֞mKA�S�X�aH�����Hā�4�c��ʒq��7�i�y1��ǯ����Z�&gt;)�� h�B�M�Hnn�U����8�z��=]OR��Q�H5q��T���H��T�523�j����*Nz�n]7���N��oC�HB4(�A{���y��W����we�þ	����-�ખ9�6�%A�����];�D�+JZR�����'!����2j����uf�O�%l��l��]��,�J��#M#&lt;�H9f��k5��:�w�Ǘ��[��N3�8�����Jѧ�-���&lt;�&lt;%�����T�����f�v����^��i��Ig�nw�ےğ����u�i�t.�A��[��,�Y��$��2��,�8T2��j����S7��u��z��T�̪�� ��zכ�_�B���7VS���[����/����s4��`B�� ���@��4�˚_��k߯�TgZ�g(_�K�;ok_^���4y泩���cbjw��	�n�J�y��;Ćq�&lt;�OZͲ�|ۿ��O�4��ˎ@-�1��Nrk�~#����?��4O���|9�� ����4MY����n5j3h:Ƶ��� Owkm�k�i~2���V^&amp;�t��"�Nv�Y��v-+&lt;h�xR7-��a�����2�&lt;��e8���������X���=��E�&lt;/�x_�^3l\)ۂsWo�0F� ����gf1�9�ҵn�-ܲ�]�	��qn=2O^�w���w��Q�*�K}1��ׯJ`Oon��K3��'v:q��g��q�[H�Q����,�u��'�j�����!�A#�
+�p���jH�zm�%_[wES�o���Ӛ �.��?�Ю����/s�����y�Ud��Ɂ��T��x����f]��l�w+9'���y�=�K�\�mMܯ	 OǠ�
+�.���.�k�i�/eqm�Lo}�$�)�R�J$����-�ݰ�����vv���9h��� �rL�S74��d���ln���I{%޻u29�$��B���Q1H��'�''�-ê�Oɱ���=vfR����3|̎"cU����W��p�=N��AQ�i�~��
+���?����`�"�u��o��2:����J�M1����8�\�^��&gt;P����#=x�]��.�R��29�{�÷lw��G����G�&gt;�%�!'�B�`mɹaus�����A;�� {����ߎt/ǟ�����K�������z�7�|/�������V��:��yo~��� 	�bS����E��6J����S�pq8p��p~�~4O�� ��O�����~8��|���q��K�S�$�\%M���Mr=B�;R{�&amp;	Q_'ǹ=&lt;�3�$�z�0�1�:���b0�U��XFt��{Nm\����!�O��Uk��׏٩J�XS������˾����d���(٫�z���_��E�/��+��������==�8��^v�_��3�`?��,�e�^� y.D��&lt;����R��*߭����u�����T����i�t�o�����=1~1|C���rz��ٞ����Epv�,���y�^���_���q?�����޼�����O�  ������l&gt;;�P�~[�Q�mQ��e����%��6�e!��Ȏ�#`��������#�4�W����e���S�\L5�糊ٌ�X-�ƒVX���U����ս?�Z����G|��O�$g�H��&lt;��di@ڤ����5��oM�u��xoĺE��I�궫��ʬ���#g r:��_��AT��0����V�1XI���5�_�F|�ν�KkT�/捵G�_�#����!�a14'��ƝN�9S�Ea��ΎI���Su#zu4��W�~~��X�}c���$��ԭ�!��ȷC,l8�VEq��;v��R�w�9����{7��  �C�o�5X�-g��_Y6�%�R(��nf��yT�V;�� y��_0G�Eit���s�z��q�_ʞ&amp;q?���5�Ζ�7;�OZ����NS�|�����K�G��a8����%^�&amp;�S�P�&amp;~һ���Բ��m��M����sǾ?�A5��69����
+�b�yF
+A��=�����y��[��
+I#�V m-�=�1ǯ���]]�i�w&gt;�S�����������T��/�� Z.��.�ծ�L��K�e��[�+�S�!ӧ�`�O-����|�]vo�~�S��������]�$�m��F=A;��k��6o|f�χZA�O�+I�*&gt;���槩�7R���J��V'� ���ň丹�g|�wV���dR�n��;�N�.Z%&lt;� ����.��༚�V���&lt;Ƭ��RU#��%	����m�qN&amp;�/���Xa��5B�"�:;k���w��5Ǎ�Is�5��'���������&gt;�����]k|��Q�M+H\��Ő5̓�ʏ���F��'%B��~��M_�r@�+��.�%c��2�͌|��LҜ��+�N�|Ѯ��5k��q�i1�-&gt;�)m�I3\��Nv�����oA�R���Ge��w���ګ�&lt;����}�j[��Z�����%�`�vf u�3�8�]��jE�*�A`O���&gt;�A���@�m�3yqD�&lt;͠)����z7@B�ʁ��,-���ݼ�����Ln�����S����v����N)+���(�-����~*���:�-ɳ"Ơ�e\;���F� 0�\�y�����[?����i���?�yo#�w��[ʷZt�H�v����ZK�+?�p���^����a�nt{�b��J���������z���Ei�ހp��%�f0#��bV�~\[�m���.O�*�i9Z��� �tьhS�4����Nח]�m�����s��~/�Z���$kzƷ�x�Ş3��,tK�����S�n�4�I���S����,`��m��;-KҬ&lt;�Y&lt;�M��E�0�R�p�nڸ���=:ޢ�u`�Hg�@Z"d1,�"�'$3���q��1Un�Vr�9E�1�p��
+����m�r1J1��,U�^����c�}o#kV%�@��A��w�w c��Q�M�6�-��3�:��3��?&lt;�U�dY�'h*�ǜ��voQ�=q�POq@	�+��d�`7�A#�g����ڸ\yJ�������^����M�,7*3o�VV��݀N3�}2J�w:��o1@;s�T���k.rF&lt;9�mJ_�i�E" r� �B���.F9� E}2I��T�˼�9�7`g�z�F��A�����^v�|�*n�%&gt;��f��,o&amp;�r��9�c��Lg�$��x�C3�n���`Z,y� ;s�� }�����g�9���&gt;�5_4�YS�M���O�X�}s���+{=8���M��I�m��}�T�u���k�ti�y��E�m�e}DD��up~Ϧ���H���cY���X�ํL��}v|�a�l��09�ǽgO�����o-�(�;��H��OZް��o3-ض�W�1�#�rJw"����V�@��I���R�$#s����^����hms_M�S�ɩ'��P������r�?�O�{��v�T����;P�d?2�[���z9,�#���?�n����2��8����*�p$���̠`9� �u��_U[F�Z�t�Fn-4MV�p�7Zv���`�������+�!�&amp;�J�r�jP�	y���K�ȗ���*�/V2��z5#��(W�m_�����i��՗2G�G�ܒ�m8ʐq�FpI�j	c�i4TUS��rr�?��M	5)���W����O%�~h$1�+�����s�֋�kx�����ʸ6�{�/�~�ɯ����gˆĸsI�q�]�^��?g��W���_���Ҟ"�e)FUi�z(��ͫoe�����w)TO ���O��׃JװA�֪ǮB/O\x��|�Xf���� �J� �������gB������|������}]�G��X��a��o�n�m��(ⳉ%Y��ف�#�����M|E��g����l���KE��1C�����l��8��C�~U,[���઺Υ����&gt;��]Ia��t��7��%���M�,g� ��A��gşˤ�&gt;+���R��2%�nBE!/���g
+0�D}�%6�5�	[����*1�+a��	/g��M]_���B���Qu��i85�i�;(�&gt;W���mo���l�G�wv_ھ=��k�ɭ�a���P�Jd�� �%�b�:�U�|�������"����Qqo��[+�l1���``nG^���q�/�~)����[q�I��/��R�W���tP��y�0 $WS���� �o�5k�&lt;!lZ�ˮ�o�2K�mܱ ��pF*�p6O��Ɲx�*�'.j� yy4仺w�e�S��f��4�N�a[�FNo��N����6K��v�����z7���K��6����qskr׬�g7�4rp��2��r0Z紝�v͗�oEӈ/ۯ∺����rzu��	|�[@�/���\��|E$�_i�@+�2��|�+ FC7�����g|W��#��O�� |�(�G���cř�%zx��%�fT�ʴiQ�ቔ�9�E��j�?f�Q��m���\Fu��p��&amp;�2�.���T�J�����Z�8Y�5v���L�x�^*� �������+�|9�� 	Eqn�e���";�$n+�Os��&gt;���x?��?+�_u��Z�%|��Coq�¼,���� �.�=�#Ҿ���yq��������S�˩A �=�5���'�[\JW���6��|B��3�O��;B��:����?o���|&gt;[�O���(��7�:t)��{K�ڽ��j֩��_V\�15�W��j��޽~+]�k�4.폃�u=Ru���k�?AL0tӦe7z��#u[8w�s޸ ��{��t��_��i�/�[�%p$H]"��̻2�
+�Nrk�+���]{A{�^c���A�����e#�V$~�F.�,s�}a��l[���q�����$�&gt;Q��@z�H������ZV�-�.���%��"��ԦV[kTi|�
+F�o�d�� �W��K��i��˖`���"�L�ی9��n��p�d�4�bf�8K�g�s�� p:W��L��㲍�ۤ0����Wb}K3OҺf����o�&lt;�
+U�
+r���V��.������&amp;�yⸯq#����g���n��lC|�:��+�F'��k2�_\��:m�|�e�Z4�8��
+�N�SY3���u?
+�� ���"c�4�-�T;]a��mR�Bʋ���,�
+���i�kCn�i�һ����!�\�2@�wg� ��`��Z�o��w��#.k��S6�k��,e��?(�+�*�1�w�aI}�VM�2�5[S3 �T�g��=8���\/����P���Qb�c�V$NK��,j�ܝ����B��i�&lt;v*�[�Ǡ�F�GEb�����獠��s���d�W����!@v�&gt;��~u�m4���������0ܠd�z���;�=3y2v�¨�a�N�1� ߦ)d�L�X!N� '��p3��j��������q&lt;��x\��� }(�֐�ܻ����̤��ǯ�R��&gt;٧KĢ�$��|��sv�d�;W&lt;Ms�%ˮ&amp;~e�s�y��zן�e��&lt;��&gt;�&gt;k
+�99]����mk��E3���k=6[��̺y�h�9��#t�?���{U��%h���v�wf$` :��dט�%���)rc�W�.��1�H�g����G�������U����Ư�wJA-#�q�GkHG�*7����71�X,G�����#��Hu�&gt;�| {ny2;��]����3�A��q�.X�am&gt;X�� {�� =j���3&amp;��w/��-��ǭX&gt;����oN�x�G?0��&lt;�ȯ�&gt;�y�u�O���h�� �:'���K�m��KV��C�ʻ�V��I9
+��&gt;ƾӘ��/�Ϩی{u����'ƛi�~��=����&gt;&gt;|3��2�Aw�@�#�֐A&amp; ���&lt;d�.YG�qv����q+?[�V+̜��Ty�{^*�f���-~��3�� ��� �� &lt;e�/��]}�YCi��t[�?��(�L�:)U
+��:��4�����֣������K;1ѠU+eU�&amp;I1��rx��� m�����e�Y5洞h#��_%b�7�#���x���g�|�����թ�����Z�@�2&gt;�־����~�!��9vk��C��1*ul�t�/��i���۩�'�?�&gt;q���s��'�b��~����ώ������S�c8��5e�u�|g� ����ִ�M�{i��es&lt;�m�YI��x�2+�� P}I�����s�h������d��o�.f�x��(�;�N���N &lt;�_�8���W�c�y*J�fῺ�^�� ���_�%:Uxۈ'R5*9J9�eg�75��j;w��?��
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 162
+
+{
+  "profileImageUrl" : "https://s3.ap-northeast-2.amazonaws.com/dongoorami-image/member/42fe2c73-5224-4cf2-ae21-47600d5ac5a0-%EA%B9%80%EC%98%81%ED%95%9C.JPG"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 주소</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_프로필_정보_수정"><a class="link" href="#_프로필_정보_수정">프로필 정보 수정</a></h3>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjY0fQ.MQE7P3AGNmkukrUE5TdVBAqrEOLNzX59QyDdFkhTR6E
+Content-Length: 102
+Host: localhost:8080
+
+{
+  "gender" : "남자",
+  "birthDate" : [ 2000, 12, 31 ],
+  "introduction" : "안녕하세요~"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">남자/여자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>birthDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>LocalDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생년월일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>introduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한줄 소개</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 140
+
+{
+  "name" : "김뫄뫄",
+  "profileImage" : "image.png",
+  "gender" : "남자",
+  "age" : 25,
+  "introduction" : "안녕하세요~"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">남자/여자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>introduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한줄 소개</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_프로필_정보_조회"><a class="link" href="#_프로필_정보_조회">프로필 정보 조회</a></h3>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjYzfQ.Ql6Yz4F9iCl7JTQ3mqsKkRaw_qXA5m9GBh1OY4nPVOo
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 140
+
+{
+  "name" : "김뫄뫄",
+  "profileImage" : "image.png",
+  "gender" : "남자",
+  "age" : 25,
+  "introduction" : "안녕하세요~"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">남자/여자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>introduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한줄 소개</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_동행_api"><a class="link" href="#_동행_api">동행 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_동행_구인_게시글_작성"><a class="link" href="#_동행_구인_게시글_작성">동행 구인 게시글 작성</a></h3>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/accompany/posts HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjU5fQ.5KPVNwspFnKICr6Y8wQ_bwnFl1XKF_SOPSbIHwWaPl4
+Content-Length: 385
+Host: localhost:8080
+
+{
+  "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+  "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+  "concertPlace" : "KSPO DOME",
+  "region" : "서울",
+  "startAge" : 23,
+  "endAge" : 37,
+  "totalPeople" : 2,
+  "gender" : "여",
+  "startDate" : "2024-03-22",
+  "endDate" : "2024-03-22",
+  "content" : "같이 올라갈 사람 구해요~"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>concertName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공연명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>concertPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공연장소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>region</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지역</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startAge</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 연령</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endAge</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 연령</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPeople</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인원 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: /api/v1/accompany/posts/11
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_동행_구인_게시글_목록_조회무한_스크롤"><a class="link" href="#_동행_구인_게시글_목록_조회무한_스크롤">동행 구인 게시글 목록 조회(무한 스크롤)</a></h3>
+<div class="sect3">
+<h4 id="_동행_구인_게시글_목록_조회최초_요청"><a class="link" href="#_동행_구인_게시글_목록_조회최초_요청">동행 구인 게시글 목록 조회(최초 요청)</a></h4>
+<div class="paragraph">
+<p>최초 요청의 경우 "필요한 동행 구인글 개수(size)"만 쿼리 파라미터 값으로 전달</p>
+</div>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/accompany/posts?size=3 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjU5fQ.5KPVNwspFnKICr6Y8wQ_bwnFl1XKF_SOPSbIHwWaPl4
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청할 동행 구인글 개수</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 1132
+
+{
+  "hasNext" : true,
+  "accompanyPostInfos" : [ {
+    "id" : 10,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:39.151394",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  }, {
+    "id" : 9,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:39.142264",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  }, {
+    "id" : 8,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:39.135708",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  } ]
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 동행 구인글 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 구인글 정보 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 구인글 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].updatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">구인 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].concertName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공연명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].viewCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].totalPeople</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모집 인원 수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_동행_구인_게시글_목록_조회이후_요청"><a class="link" href="#_동행_구인_게시글_목록_조회이후_요청">동행 구인 게시글 목록 조회(이후 요청)</a></h4>
+<div class="paragraph">
+<p>이후 요청의 경우 "마지막으로 받은 게시글 id(cursorId)"를 쿼리 파라미터 값으로 함께 전달</p>
+</div>
+<div class="listingblock">
+<div class="title">Request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/accompany/posts?cursorId=17&amp;size=3 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbHNqa2dobGFza2RqZ2giLCJhdXRob3JpdGllcyI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA5MDA1NjU2fQ.XSuKyk2HSJYqN_aR0NLWLlE2vSkg8KSMBiqyEy3Q180
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cursorId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막으로 받은 동행 구인글 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청할 동행 구인글 개수</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">Response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 1131
+
+{
+  "hasNext" : true,
+  "accompanyPostInfos" : [ {
+    "id" : 5,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:36.845363",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  }, {
+    "id" : 4,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:36.837301",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  }, {
+    "id" : 3,
+    "title" : "서울 같이 갈 울싼 사람 구합니다~~",
+    "writer" : "김뫄뫄",
+    "updatedAt" : "2024-02-27T11:47:36.830141",
+    "status" : "모집 중",
+    "concertName" : "2024 SG워너비 콘서트 : 우리의 노래",
+    "viewCount" : 0,
+    "commentCount" : 0,
+    "gender" : "여",
+    "totalPeople" : 2
+  } ]
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 동행 구인글 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 구인글 정보 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동행 구인글 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].updatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">구인 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].concertName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공연명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].viewCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].gender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accompanyPostInfos[].totalPeople</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모집 인원 수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-21 10:13:52 +0900
+Last updated 2024-02-27 02:34:24 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -54,6 +54,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
@@ -317,7 +318,9 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
-        member.updateInfo("여자", LocalDate.of(2001, 1, 17), "안녕하세요~");
+        ReflectionTestUtils.setField(member, "gender", "여자");
+        ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
+        ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
         memberRepository.save(member);
         String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
                 member.getRoles());
@@ -423,7 +426,9 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
-        member.updateInfo("여자", LocalDate.of(2001, 1, 17), "안녕하세요~");
+        ReflectionTestUtils.setField(member, "gender", "여자");
+        ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
+        ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
         memberRepository.save(member);
         String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
                 member.getRoles());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #24
![image](https://github.com/GoGo-Ring/dongoorami-backend/assets/90572599/924f964c-9812-4d29-bdbf-8d5f10e03631)

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 최초 로그인(회원가입) 시 성별, 생년월일 저장하는 signup 구현
- updateMember에서 닉네임, 한줄소개만 수정하는 것으로 구현 수정
- 회원 엔티티 필드에 매너 지수 추가

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
