### PR TITLE
feat #21: 동행 구인글 작성, 수정, 단건 조회 api 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -78,12 +78,16 @@ include::{snippets}/MemberControllerTest/getMember/http-response.adoc[]
 include::{snippets}/MemberControllerTest/getMember/response-fields.adoc[]
 
 == 동행 API
+
+=== 동행 목적 종류
+관람, 숙박, 이동
+
 === 동행 구인 게시글 작성
 
 .Request
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/http-request.adoc[]
-include::{snippets}/AccompanyControllerTest/createAccompanyPost/form-parameters.adoc[]
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/request-parts.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPost/request-part-accompanyPostRequest-fields.adoc[]
 
 .Response
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/http-response.adoc[]
@@ -145,9 +149,9 @@ include::{snippets}/AccompanyControllerTest/getAccompanyComments/response-fields
 
 .Request
 include::{snippets}/AccompanyControllerTest/updateAccompanyPost/http-request.adoc[]
-include::{snippets}/AccompanyControllerTest/updateAccompanyPost/form-parameters.adoc[]
-include::{snippets}/AccompanyControllerTest/updateAccompanyPost/request-parts.adoc[]
 include::{snippets}/AccompanyControllerTest/updateAccompanyPost/path-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/request-parts.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPost/request-part-accompanyPostRequest-fields.adoc[]
 
 .Response
 include::{snippets}/AccompanyControllerTest/updateAccompanyPost/http-response.adoc[]

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -5,10 +5,12 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface AccompanyService {
 
-    Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId);
+    Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images, Long memberId);
 
     AccompanyPostsResponse getAccompanyPosts(Long cursorId, int size);
 
@@ -19,7 +21,7 @@ public interface AccompanyService {
 
     AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId);
 
-    void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId,
+    void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images, Long memberId,
             Long accompanyPostId);
 
     void deleteAccompanyPost(Long memberId, Long accompanyPostId);

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -12,7 +12,7 @@ public interface AccompanyService {
 
     AccompanyPostsResponse getAccompanyPosts(Long cursorId, int size);
 
-    AccompanyPostResponse getAccompanyPost(Long accompanyPostId);
+    AccompanyPostResponse getAccompanyPost(Long memberId, Long accompanyPostId);
 
     Long createAccompanyComment(Long accompanyPostId,
             AccompanyCommentRequest accompanyCommentRequest, Long memberId);

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -69,7 +69,7 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     @Transactional
     @Override
-    public AccompanyPostResponse getAccompanyPost(Long accompanyPostId) {
+    public AccompanyPostResponse getAccompanyPost(Long memberId, Long accompanyPostId) {
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
@@ -77,7 +77,8 @@ public class AccompanyServiceImpl implements AccompanyService {
         accompanyPost.increaseViewCount();
 
         return AccompanyPostResponse.of(accompanyPost,
-                MemberInfo.of(accompanyPost.getMember()));
+                MemberInfo.of(accompanyPost.getMember()),
+                isMemberIsWriter(accompanyPost.getId(), memberId));
     }
 
     @Override
@@ -141,9 +142,13 @@ public class AccompanyServiceImpl implements AccompanyService {
     }
 
     private void checkMemberIsWriter(AccompanyPost accompanyPost, Long memberId) {
-        if (accompanyPost.getMember().getId() != memberId) {
+        if (!isMemberIsWriter(accompanyPost.getMember().getId(), memberId)) {
             throw new OnlyWriterCanModifyException(AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND);
         }
+    }
+
+    private boolean isMemberIsWriter(Long writerId, Long memberId){
+        return writerId == memberId;
     }
 
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -39,10 +40,10 @@ public class AccompanyServiceImpl implements AccompanyService {
     private final S3ImageUtil s3ImageUtil;
 
     @Override
-    public Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId) {
+    public Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images, Long memberId) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        List<String> imageUrls = s3ImageUtil.putObjects(accompanyPostRequest.getImages(),
+        List<String> imageUrls = s3ImageUtil.putObjects(images,
                 ImageType.ACCOMPANY_POST);
 
         return accompanyPostRepository.save(accompanyPostRequest.toEntity(member, imageUrls))
@@ -114,7 +115,7 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     @Transactional
     @Override
-    public void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, Long memberId,
+    public void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images, Long memberId,
             Long accompanyPostId) {
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
@@ -123,7 +124,7 @@ public class AccompanyServiceImpl implements AccompanyService {
         checkMemberIsWriter(accompanyPost, memberId);
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        List<String> imageUrls = s3ImageUtil.putObjects(accompanyPostRequest.getImages(),
+        List<String> imageUrls = s3ImageUtil.putObjects(images,
                 ImageType.ACCOMPANY_POST);
         s3ImageUtil.deleteObjects(accompanyPost.getImages(), ImageType.ACCOMPANY_POST);
         accompanyPost.update(accompanyPostRequest.toEntity(member, imageUrls));

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -1,5 +1,7 @@
 package com.gogoring.dongoorami.accompany.domain;
 
+import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
+import com.gogoring.dongoorami.accompany.exception.InvalidAccompanyPurposeTypeException;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.persistence.ElementCollection;
@@ -13,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,7 +28,7 @@ import lombok.NoArgsConstructor;
 public class AccompanyPost extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
-    private final RecruitmentStatus status = RecruitmentStatus.PROCEEDING;
+    private final RecruitmentStatusType status = RecruitmentStatusType.PROCEEDING;
     @OneToMany(mappedBy = "accompanyPost")
     private final List<AccompanyComment> accompanyComments = new ArrayList<>();
     private Long viewCount = 0L;
@@ -47,11 +50,14 @@ public class AccompanyPost extends BaseEntity {
     private String content;
     @ElementCollection
     private List<String> images;
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private List<AccompanyPurposeType> purposes;
 
     @Builder
     public AccompanyPost(Member member, String title, String concertName, String concertPlace,
             String region, Long startAge, Long endAge, Long totalPeople, String gender,
-            LocalDate startDate, LocalDate endDate, String content, List<String> images) {
+            LocalDate startDate, LocalDate endDate, String content, List<String> images, List<AccompanyPurposeType> purposes) {
         this.member = member;
         this.title = title;
         this.concertName = concertName;
@@ -65,6 +71,7 @@ public class AccompanyPost extends BaseEntity {
         this.endDate = endDate;
         this.content = content;
         this.images = images;
+        this.purposes = purposes;
     }
 
     public void increaseViewCount() {
@@ -89,19 +96,40 @@ public class AccompanyPost extends BaseEntity {
         this.endDate = accompanyPost.endDate;
         this.content = accompanyPost.content;
         this.images = accompanyPost.images;
+        this.purposes = accompanyPost.purposes;
     }
 
-    public enum RecruitmentStatus {
+    public enum RecruitmentStatusType {
         PROCEEDING("모집 중"), COMPLETED("모집 완료");
 
         String name;
 
-        RecruitmentStatus(String name) {
+        RecruitmentStatusType(String name) {
             this.name = name;
         }
 
         public String getName() {
             return name;
+        }
+    }
+
+    public enum AccompanyPurposeType {
+        ENJOY("관람"), ACCOMMODATION("숙박"), TRANSPORTATION("이동");
+
+        String name;
+
+        AccompanyPurposeType(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public static AccompanyPurposeType getValue(String name){
+            return Arrays.stream(AccompanyPurposeType.values()).filter(
+                            accompanyPurposeType -> accompanyPurposeType.getName().equals(name)).findAny()
+                    .orElseThrow(() -> new InvalidAccompanyPurposeTypeException(AccompanyErrorCode.INVALID_ACCOMPANY_PURPOSE_TYPE));
         }
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyPostRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyPostRequest.java
@@ -1,11 +1,13 @@
 package com.gogoring.dongoorami.accompany.dto.request;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -55,7 +57,8 @@ public class AccompanyPostRequest {
     @NotBlank(message = "content은 공백일 수 없습니다.")
     private String content;
 
-    private List<MultipartFile> images;
+    @Size(min=1, message = "purposes는 1개 이상 필요합니다.")
+    private List<String> purposes;
 
     public AccompanyPost toEntity(Member member, List<String> images) {
         return AccompanyPost.builder()
@@ -72,6 +75,7 @@ public class AccompanyPostRequest {
                 .startAge(startAge)
                 .member(member)
                 .images(images)
+                .purposes(purposes.stream().map(AccompanyPurposeType::getValue).toList())
                 .build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
@@ -1,6 +1,7 @@
 package com.gogoring.dongoorami.accompany.dto.response;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,8 +36,10 @@ public class AccompanyPostResponse {
     private List<String> images;
     private Boolean isWish;
     private Boolean isWriter;
+    private List<String> purposes;
 
-    public static AccompanyPostResponse of(AccompanyPost accompanyPost, MemberInfo writer, Boolean isWriter) {
+    public static AccompanyPostResponse of(AccompanyPost accompanyPost, MemberInfo writer,
+            Boolean isWriter) {
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
                 .title(accompanyPost.getTitle())
@@ -60,6 +63,8 @@ public class AccompanyPostResponse {
                 .images(accompanyPost.getImages())
                 .isWish(true) // 임시
                 .isWriter(isWriter)
+                .purposes(accompanyPost.getPurposes().stream().map(AccompanyPurposeType::getName)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
@@ -34,8 +34,9 @@ public class AccompanyPostResponse {
     private String content;
     private List<String> images;
     private Boolean isWish;
+    private Boolean isWriter;
 
-    public static AccompanyPostResponse of(AccompanyPost accompanyPost, MemberInfo writer) {
+    public static AccompanyPostResponse of(AccompanyPost accompanyPost, MemberInfo writer, Boolean isWriter) {
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
                 .title(accompanyPost.getTitle())
@@ -58,6 +59,7 @@ public class AccompanyPostResponse {
                 .content(accompanyPost.getContent())
                 .images(accompanyPost.getImages())
                 .isWish(true) // 임시
+                .isWriter(isWriter)
                 .build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AccompanyErrorCode {
     ACCOMPANY_POST_NOT_FOUND("게시글이 존재하지 않습니다."),
-    ONLY_WRITER_CAN_MODIFY("게시글의 작성자만 수정할 수 있습니다.");
+    ONLY_WRITER_CAN_MODIFY("게시글의 작성자만 수정할 수 있습니다."),
+    INVALID_ACCOMPANY_PURPOSE_TYPE("유효하지 않은 동행 목적입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -26,4 +26,12 @@ public class AccompanyGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(InvalidAccompanyPurposeTypeException.class)
+    public ResponseEntity<ErrorResponse> catchInvalidAccompanyPurposeTypeExceptionException(
+            InvalidAccompanyPurposeTypeException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/InvalidAccompanyPurposeTypeException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/InvalidAccompanyPurposeTypeException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidAccompanyPurposeTypeException extends RuntimeException {
+
+    private final String errorCode;
+
+    public InvalidAccompanyPurposeTypeException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -9,17 +9,21 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/accompany")
@@ -37,15 +41,17 @@ public class AccompanyController {
 
     @GetMapping("/posts/{accompanyPostId}")
     public ResponseEntity<AccompanyPostResponse> getAccompanyPost(
-            @PathVariable Long accompanyPostId) {
-        return ResponseEntity.ok(accompanyService.getAccompanyPost(accompanyPostId));
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(accompanyService.getAccompanyPost(customUserDetails.getId(), accompanyPostId));
     }
 
     @PostMapping("/posts")
     public ResponseEntity<Void> createAccompanyPost(
-            @Valid AccompanyPostRequest accompanyPostRequest,
+            @Valid @RequestPart AccompanyPostRequest accompanyPostRequest,
+            @RequestPart List<MultipartFile> images,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long accompanyPostId = accompanyService.createAccompanyPost(accompanyPostRequest,
+        Long accompanyPostId = accompanyService.createAccompanyPost(accompanyPostRequest, images,
                 customUserDetails.getId());
         return ResponseEntity.created(URI.create("/api/v1/accompany/posts/" + accompanyPostId))
                 .build();
@@ -70,10 +76,11 @@ public class AccompanyController {
 
     @PostMapping("/posts/{accompanyPostId}")
     public ResponseEntity<Void> updateAccompanyPost(
-            @Valid AccompanyPostRequest accompanyPostRequest,
+            @Valid @RequestPart AccompanyPostRequest accompanyPostRequest,
+            @RequestPart List<MultipartFile> images,
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        accompanyService.updateAccompanyPost(accompanyPostRequest, customUserDetails.getId(),
+        accompanyService.updateAccompanyPost(accompanyPostRequest, images, customUserDetails.getId(),
                 accompanyPostId);
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -373,7 +373,8 @@ class AccompanyControllerTest {
                                 fieldWithPath("content").type(STRING).description("내용"),
                                 fieldWithPath("images").type(ARRAY).description("이미지 리스트"),
                                 fieldWithPath("isWish").type(BOOLEAN).description("찜 여부"),
-                                fieldWithPath("isWriter").type(BOOLEAN).description("본인 작성 여부")
+                                fieldWithPath("isWriter").type(BOOLEAN).description("본인 작성 여부"),
+                                fieldWithPath("purposes").type(ARRAY).description("동행 목적 리스트")
                         )
                 ));
         Long afterViewCount = accompanyPostRepository.findById(accompanyPost.getId()).get()
@@ -610,7 +611,9 @@ class AccompanyControllerTest {
                     .startAge(23L)
                     .endAge(37L)
                     .totalPeople(2L)
-                    .images(createImageUrls(2)).build());
+                    .images(createImageUrls(2))
+                    .purposes(Arrays.asList(AccompanyPurposeType.ACCOMMODATION,
+                            AccompanyPurposeType.TRANSPORTATION)).build());
         }
 
         return accompanyPosts;

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -371,7 +371,8 @@ class AccompanyControllerTest {
                                 fieldWithPath("waitingCount").type(NUMBER).description("대기 인원 수"),
                                 fieldWithPath("content").type(STRING).description("내용"),
                                 fieldWithPath("images").type(ARRAY).description("이미지 리스트"),
-                                fieldWithPath("isWish").type(BOOLEAN).description("찜 여부")
+                                fieldWithPath("isWish").type(BOOLEAN).description("찜 여부"),
+                                fieldWithPath("isWriter").type(BOOLEAN).description("본인 작성 여부")
                         )
                 ));
         Long afterViewCount = accompanyPostRepository.findById(accompanyPost.getId()).get()


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolving #21

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 동행 구인글 작성 및 수정 시, 동행 목적 필드 추가
- 동행 게시글 단건 조회 시, 본인 작성 여부 필드 추가
- 동행 구인글 작성/수정 api 요청 시, 이미지와 dto 따로 받도록 수정

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
동행 구인글 작성/수정 api 요청 시, 기존에는 dto에 List<MultipartFile> images 필드를 넣어 함께 받도록 하였으나
RestDocs 문서화에 어려움이 있어서 따로 받도록 수정하였습니다!
참고
[공식 문서 Documenting a Request Part’s Fields](https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/#documenting-your-api-request-parts-payloads-fields)
[@RequestPart를 이용한 MultipartFile, DTO 처리 및 테스트](https://velog.io/@zvyg1023/Spring-Boot-RequestPart%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-MultipartFile-DTO-%EC%B2%98%EB%A6%AC-%EB%B0%8F-%ED%85%8C%EC%8A%A4%ED%8A%B8)