### PR TITLE
refactor #27: 로그인 성공 시 토큰 넘겨주는 방식 변경

### DIFF
--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,10 +1,12 @@
 package com.gogoring.dongoorami.global.oauth2;
 
 import com.gogoring.dongoorami.global.jwt.TokenProvider;
-import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
@@ -25,28 +25,39 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) throws IOException, ServletException {
+            Authentication authentication) throws IOException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
         String accessToken = tokenProvider.createAccessToken(oAuth2User.getProviderId(),
                 (List<GrantedAuthority>) oAuth2User.getAuthorities());
         String refreshToken = tokenProvider.createRefreshToken(oAuth2User.getProviderId());
-        Boolean isFirstLogin = oAuth2User.getMember().getBirthDate() == null;
-        String uri = createURI(accessToken, refreshToken, isFirstLogin);
+        boolean isFirstLogin = oAuth2User.getMember().getBirthDate() == null;
 
+        accessToken = URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+        accessTokenCookie.setPath("/oauth");
+        accessTokenCookie.setHttpOnly(true);
+        response.addCookie(accessTokenCookie);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setPath("/oauth");
+        refreshTokenCookie.setHttpOnly(true);
+        response.addCookie(refreshTokenCookie);
+
+        Cookie isFirstLoginCookie = new Cookie("isFirstLogin", Boolean.toString(isFirstLogin));
+        isFirstLoginCookie.setPath("/oauth");
+        isFirstLoginCookie.setHttpOnly(true);
+        response.addCookie(isFirstLoginCookie);
+
+        String uri = createURI();
         getRedirectStrategy().sendRedirect(request, response, uri);
     }
 
-    private String createURI(String accessToken, String refreshToken, Boolean isFirstLogin) {
-        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-        queryParams.add("accessToken", accessToken);
-        queryParams.add("refreshToken", refreshToken);
-        queryParams.add("isFirstLogin", isFirstLogin.toString());
-
+    private String createURI() {
         return UriComponentsBuilder
                 .newInstance()
                 .path("/oauth")
-                .queryParams(queryParams)
                 .build()
                 .toUri().toString();
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #27 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 어제 프론트에서 요청 있었던대로 로그인 성공 시 리다이렉트 uri에서 파라미터 대신 쿠키로 토큰, 최초 로그인 여부 전달하도록 구현 변경하였습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
- accessToken만 인코딩이 들어간 것은 Tomcat 8.5 이후 버전부터 새로 추가된 Cookie 규칙의 영향입니다.
**semicolon (;), comma (,), equal sign (=), and space cannot be used in the cookie value**

accessToken이 'Bearer ~~~' 형식이라 공백이 있어 인코딩 처리하였습니다.