### PR TITLE
feat #22: 외부 api 호출을 통한 공연 정보 등록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.json:json:20240205'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/gogoring/dongoorami/DongooramiApplication.java
+++ b/src/main/java/com/gogoring/dongoorami/DongooramiApplication.java
@@ -3,7 +3,9 @@ package com.gogoring.dongoorami;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class DongooramiApplication {

--- a/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
@@ -1,0 +1,109 @@
+package com.gogoring.dongoorami.concert.domain;
+
+import com.gogoring.dongoorami.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Concert extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String kopisId;
+
+    @Column(columnDefinition = "TEXT")
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String startedAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String endedAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String place;
+
+    @Column(columnDefinition = "TEXT")
+    private String cast;
+
+    @Column(columnDefinition = "TEXT")
+    private String crew;
+
+    @Column(columnDefinition = "TEXT")
+    private String runtime;
+
+    @Column(columnDefinition = "TEXT")
+    private String age;
+
+    @Column(columnDefinition = "TEXT")
+    private String producer;
+
+    @Column(columnDefinition = "TEXT")
+    private String agency;
+
+    @Column(columnDefinition = "TEXT")
+    private String host;
+
+    @Column(columnDefinition = "TEXT")
+    private String management;
+
+    @Column(columnDefinition = "TEXT")
+    private String cost;
+
+    private String poster;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    private String genre;
+
+    private String status;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> introductionImages;
+
+    @Column(columnDefinition = "TEXT")
+    private String schedule;
+
+    @Builder
+    public Concert(String kopisId, String name, String startedAt, String endedAt, String place,
+            String cast, String crew, String runtime, String age, String producer, String agency,
+            String host, String management, String cost, String poster, String summary,
+            String genre, String status, List<String> introductionImages, String schedule) {
+        this.kopisId = kopisId;
+        this.name = name;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.place = place;
+        this.cast = cast;
+        this.crew = crew;
+        this.runtime = runtime;
+        this.age = age;
+        this.producer = producer;
+        this.agency = agency;
+        this.host = host;
+        this.management = management;
+        this.cost = cost;
+        this.poster = poster;
+        this.summary = summary;
+        this.genre = genre;
+        this.status = status;
+        this.introductionImages = introductionImages;
+        this.schedule = schedule;
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertErrorCode.java
@@ -1,0 +1,13 @@
+package com.gogoring.dongoorami.concert.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ConcertErrorCode {
+
+    CONCERT_NOT_FOUND("공연 정보가 존재하지 않습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertGlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.gogoring.dongoorami.concert.exception;
+
+import com.gogoring.dongoorami.global.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ConcertGlobalExceptionHandler {
+
+    @ExceptionHandler(ConcertNotFoundException.class)
+    public ResponseEntity<ErrorResponse> catchConcertNotFoundException(ConcertNotFoundException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertNotFoundException.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/exception/ConcertNotFoundException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.concert.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ConcertNotFoundException extends RuntimeException {
+
+    private final String errorCode;
+
+    public ConcertNotFoundException(ConcertErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/kopis/KopisHttpInterface.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/kopis/KopisHttpInterface.java
@@ -1,0 +1,17 @@
+package com.gogoring.dongoorami.concert.kopis;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+
+public interface KopisHttpInterface {
+
+    @GetExchange
+    String findAll(@RequestParam String service, @RequestParam String stdate,
+            @RequestParam String eddate, @RequestParam Integer cpage, @RequestParam Integer rows,
+            @RequestParam String newsql);
+
+    @GetExchange("/{kopisId}")
+    String findByKopisId(@PathVariable String kopisId, @RequestParam String service,
+            @RequestParam String newsql);
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/kopis/KopisService.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/kopis/KopisService.java
@@ -1,0 +1,168 @@
+package com.gogoring.dongoorami.concert.kopis;
+
+import com.gogoring.dongoorami.concert.domain.Concert;
+import com.gogoring.dongoorami.concert.exception.ConcertErrorCode;
+import com.gogoring.dongoorami.concert.exception.ConcertNotFoundException;
+import com.gogoring.dongoorami.concert.repository.ConcertRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.XML;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class KopisService {
+
+    private final ConcertRepository concertRepository;
+    private final KopisHttpInterface kopisHttpInterface;
+
+    @Value("${kopis.key}")
+    private String serviceKey;
+
+    @Scheduled(cron = "0 0 15 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void createConcerts() {
+        List<String> kopisIds = getAllFromKopis();
+        for (String kopisId : kopisIds) {
+            if (!concertRepository.existsByKopisId(kopisId)) {
+                try {
+                    Concert concert = getByKopisId(kopisId).orElseThrow(
+                            () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
+                    concertRepository.save(concert);
+                } catch (HttpClientErrorException | ConcertNotFoundException e) {
+                    log.warn(e.getMessage() + " index: " + kopisIds.indexOf(kopisId) + " id: "
+                            + kopisId, e);
+                }
+            }
+        }
+    }
+
+    private List<String> getAllFromKopis() {
+        List<String> kopisIds = new ArrayList<>();
+
+        try {
+            int page = 1;
+            while (true) {
+                String result;
+                try {
+                    result = kopisHttpInterface.findAll(serviceKey, LocalDate.now().format(
+                            DateTimeFormatter.ofPattern("yyyyMMdd")), "20241231", page, 5000, "Y");
+                } catch (HttpClientErrorException e) {
+                    log.warn(e.getMessage() + " page: " + page, e);
+                    result = kopisHttpInterface.findAll(serviceKey, LocalDate.now().format(
+                            DateTimeFormatter.ofPattern("yyyyMMdd")), "20241231", page, 5000, "Y");
+                }
+
+                if (result != null) {
+                    JSONObject jsonObject = XML.toJSONObject(result).getJSONObject("dbs");
+                    JSONArray jsonArray = jsonObject.getJSONArray("db");
+
+                    log.info("page: " + page + " length: " + jsonArray.length());
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        String kopisId = jsonArray.getJSONObject(i).getString("mt20id");
+                        kopisIds.add(kopisId);
+                    }
+                }
+
+                page++;
+            }
+        } catch (JSONException | HttpClientErrorException e) {
+            log.warn(e.getMessage(), e);
+        }
+
+        return kopisIds;
+    }
+
+    private Optional<Concert> getByKopisId(String kopisId) {
+        Concert concert = null;
+
+        try {
+            String result;
+            try {
+                result = kopisHttpInterface.findByKopisId(kopisId, serviceKey, "Y");
+            } catch (HttpClientErrorException e) {
+                log.warn(e.getMessage() + " kopisId: " + kopisId);
+                result = kopisHttpInterface.findByKopisId(kopisId, serviceKey, "Y");
+            }
+
+            if (result != null) {
+                JSONObject jsonObject = XML.toJSONObject(result).getJSONObject("dbs")
+                        .getJSONObject("db");
+
+                String name = jsonObject.get("prfnm").toString();
+                String startedAt = jsonObject.get("prfpdfrom").toString();
+                String endedAt = jsonObject.get("prfpdto").toString();
+                String place = jsonObject.get("fcltynm").toString();
+                String cast = jsonObject.get("prfcast").toString();
+                String crew = jsonObject.get("prfcrew").toString();
+                String runtime = jsonObject.get("prfruntime").toString();
+                String age = jsonObject.get("prfage").toString();
+                String producer = jsonObject.get("entrpsnmP").toString();
+                String agency = jsonObject.get("entrpsnmA").toString();
+                String host = jsonObject.get("entrpsnmH").toString();
+                String management = jsonObject.get("entrpsnmS").toString();
+                String cost = jsonObject.get("pcseguidance").toString();
+                String poster = jsonObject.get("poster").toString();
+                String summary = jsonObject.get("sty").toString();
+                String genre = jsonObject.get("genrenm").toString();
+                String status = jsonObject.get("prfstate").toString();
+                String schedule = jsonObject.get("dtguidance").toString();
+
+                List<String> introductionImages = new ArrayList<>();
+                if (jsonObject.getJSONObject("styurls").get("styurl").getClass()
+                        .equals(String.class)) {
+                    introductionImages.add(
+                            jsonObject.getJSONObject("styurls").get("styurl").toString());
+                } else {
+                    JSONArray jsonArray = jsonObject.getJSONObject("styurls")
+                            .getJSONArray("styurl");
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        String image = jsonArray.get(i).toString();
+                        introductionImages.add(image);
+                    }
+                }
+
+                concert = Concert.builder()
+                        .kopisId(kopisId)
+                        .name(name)
+                        .startedAt(startedAt)
+                        .endedAt(endedAt)
+                        .place(place)
+                        .cast(cast)
+                        .crew(crew)
+                        .runtime(runtime)
+                        .age(age)
+                        .producer(producer)
+                        .agency(agency)
+                        .host(host)
+                        .management(management)
+                        .cost(cost)
+                        .poster(poster)
+                        .summary(summary)
+                        .genre(genre)
+                        .status(status)
+                        .schedule(schedule)
+                        .introductionImages(introductionImages)
+                        .build();
+            }
+        } catch (JSONException | HttpClientErrorException e) {
+            log.warn(e.getMessage(), e);
+        }
+
+        return Optional.ofNullable(concert);
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/repository/ConcertRepository.java
@@ -1,0 +1,11 @@
+package com.gogoring.dongoorami.concert.repository;
+
+import com.gogoring.dongoorami.concert.domain.Concert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+    Boolean existsByKopisId(String kopisId);
+}

--- a/src/main/java/com/gogoring/dongoorami/global/config/RestClientConfig.java
+++ b/src/main/java/com/gogoring/dongoorami/global/config/RestClientConfig.java
@@ -1,0 +1,25 @@
+package com.gogoring.dongoorami.global.config;
+
+import com.gogoring.dongoorami.concert.kopis.KopisHttpInterface;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class RestClientConfig {
+
+    private static final String KOPIS_BASE_URL = "http://kopis.or.kr/openApi/restful/pblprfr";
+
+    @Bean
+    public KopisHttpInterface kopisConfig() {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(KOPIS_BASE_URL).build();
+        RestClientAdapter restClientAdapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory httpServiceProxyFactory = HttpServiceProxyFactory.builderFor(
+                restClientAdapter).build();
+
+        return httpServiceProxyFactory.createClient(KopisHttpInterface.class);
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #22 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- getAllFromKopis: 공연 목록 조회 api 호출, 외부 api에서의 공연 id(kopisId) 목록 리스트화
- getByKopisId: kopisId로 공연 상세 조회 api 호출
- createConcerts: getAllFromKopis, getByKopisId로 공연 목록 상세 조회 후 공연 정보 저장

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
- 코어타임 이후인 매일 오후 3시에 createConcerts 실행되도록 설정해두었습니다.
- Concert 엔티티의 필드들은 확실하게 varchar(255)를 넘지 않을 필드들을 제외하고 TEXT로 두었습니다. 
  - createConcerts를 수동 실행하여 디비에 넣어보았는데 일부 공연 정보들의 여러 필드에서 varchar(255)를 초과하는 문제가 있어 이렇게 설정하게 되었습니다...😥
- kopisHttpInterface의 메서드들을 통해 외부 api를 호출하게 되는데, 이상하게 한 번 외부 api 호출 후 또 외부 api 호출 시 HttpClientErrorException이 발생하며 호출에 실패합니다.
  - 이상하다고 생각한 이유는 호출 실패 후 같은 외부 api를 다시 호출하면 정상적으로 호출 성공하기 때문입니다...ㅎㅎㅎ 한 번의 외부 api 호출 후 대기 시간이라도 있는 것인지...
  - 일단 try-catch 문을 통해 외부 api 호출을 두 번 시도하는 방식으로 구현해두었습니다. 혼자서는 원인을 잘 모르겠어서 월요일에 kopis쪽에 문의 해보려고 합니다...!
