### PR TITLE
feat #9: 특정 멤버 정보 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -177,3 +177,13 @@ include::{snippets}/AccompanyControllerTest/getAccompanyPostRegions/http-request
 .Response
 include::{snippets}/AccompanyControllerTest/getAccompanyPostRegions/http-response.adoc[]
 include::{snippets}/AccompanyControllerTest/getAccompanyPostRegions/response-fields.adoc[]
+
+=== 특정 멤버 정보 조회
+
+.Request
+include::{snippets}/AccompanyControllerTest/getMemberProfile/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/getMemberProfile/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/getMemberProfile/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getMemberProfile/response-fields.adoc[]

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -29,4 +29,5 @@ public interface AccompanyService {
             Long accompanyPostId);
 
     void deleteAccompanyPost(Long memberId, Long accompanyPostId);
+    MemberProfile getMemberProfile(Long memberId, Long currentMemberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -6,28 +6,30 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
+import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AccompanyService {
 
     Long createAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images,
-            Long memberId);
+            Long currentMemberId);
 
     AccompanyPostsResponse getAccompanyPosts(Long cursorId, int size,
             AccompanyPostFilterRequest accompanyPostFilterRequest);
 
-    AccompanyPostResponse getAccompanyPost(Long memberId, Long accompanyPostId);
+    AccompanyPostResponse getAccompanyPost(Long currentMemberId, Long accompanyPostId);
 
     Long createAccompanyComment(Long accompanyPostId,
-            AccompanyCommentRequest accompanyCommentRequest, Long memberId);
+            AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId);
 
-    AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId);
+    AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId, Long currentMemberId);
 
     void updateAccompanyPost(AccompanyPostRequest accompanyPostRequest, List<MultipartFile> images,
-            Long memberId,
+            Long currentMemberId,
             Long accompanyPostId);
 
-    void deleteAccompanyPost(Long memberId, Long accompanyPostId);
+    void deleteAccompanyPost(Long currentMemberId, Long accompanyPostId);
+
     MemberProfile getMemberProfile(Long memberId, Long currentMemberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -137,6 +137,14 @@ public class AccompanyServiceImpl implements AccompanyService {
         accompanyPost.updateIsActivatedFalse();
     }
 
+    @Override
+    public MemberProfile getMemberProfile(Long memberId, Long currentMemberId) {
+        Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberProfile.of(member, currentMemberId);
+    }
+
     private void checkMemberIsWriter(AccompanyPost accompanyPost, Long memberId) {
         if (!isMemberIsWriter(accompanyPost.getMember().getId(), memberId)) {
             throw new OnlyWriterCanModifyException(AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND);

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -10,7 +10,7 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse.
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
-import com.gogoring.dongoorami.accompany.dto.response.MemberInfo;
+import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
 import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
 import com.gogoring.dongoorami.accompany.exception.AccompanyPostNotFoundException;
 import com.gogoring.dongoorami.accompany.exception.OnlyWriterCanModifyException;

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyCommentsResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyCommentsResponse.java
@@ -19,15 +19,16 @@ public class AccompanyCommentsResponse {
     public static class AccompanyCommentInfo {
 
         private Long id;
-        private MemberInfo memberInfo;
+        private MemberProfile memberProfile;
         private String content;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
-        public static AccompanyCommentInfo of(AccompanyComment accompanyComment) {
+        public static AccompanyCommentInfo of(AccompanyComment accompanyComment,
+                Long currentMemberId) {
             return AccompanyCommentInfo.builder()
                     .id(accompanyComment.getId())
-                    .memberInfo(MemberInfo.of(accompanyComment.getMember()))
+                    .memberProfile(MemberProfile.of(accompanyComment.getMember(), currentMemberId))
                     .content(accompanyComment.getContent())
                     .createdAt(accompanyComment.getCreatedAt())
                     .updatedAt(accompanyComment.getUpdatedAt())

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
@@ -16,7 +16,7 @@ public class AccompanyPostResponse {
 
     private Long id;
     private String title;
-    private MemberInfo memberInfo;
+    private MemberProfile memberProfile;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long viewCount;
@@ -38,8 +38,8 @@ public class AccompanyPostResponse {
     private Boolean isWriter;
     private List<String> purposes;
 
-    public static AccompanyPostResponse of(AccompanyPost accompanyPost, MemberInfo writer,
-            Boolean isWriter) {
+    public static AccompanyPostResponse of(AccompanyPost accompanyPost,
+            MemberProfile memberProfile) {
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
                 .title(accompanyPost.getTitle())
@@ -51,7 +51,7 @@ public class AccompanyPostResponse {
                 .updatedAt(accompanyPost.getUpdatedAt())
                 .viewCount(accompanyPost.getViewCount())
                 .commentCount(0L) // 임시
-                .memberInfo(writer)
+                .memberProfile(memberProfile)
                 .concertPlace(accompanyPost.getConcertPlace())
                 .region(accompanyPost.getRegion().getName())
                 .startAge(accompanyPost.getStartAge())
@@ -62,7 +62,7 @@ public class AccompanyPostResponse {
                 .content(accompanyPost.getContent())
                 .images(accompanyPost.getImages())
                 .isWish(true) // 임시
-                .isWriter(isWriter)
+                .isWriter(memberProfile.isCurrentMember())
                 .purposes(accompanyPost.getPurposes().stream().map(AccompanyPurposeType::getName)
                         .toList())
                 .build();

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/MemberProfile.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/MemberProfile.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Builder
 @Getter
 @AllArgsConstructor
-public class MemberInfo {
+public class MemberProfile {
 
     private Long id;
 
@@ -22,13 +22,16 @@ public class MemberInfo {
 
     private String introduction;
 
-    public static MemberInfo of(Member member) {
-        return MemberInfo.builder()
+    private boolean currentMember;
+
+    public static MemberProfile of(Member member, Long currentMemberId) {
+        return MemberProfile.builder()
                 .id(member.getId())
                 .age(member.getAge())
                 .introduction(member.getIntroduction())
                 .name(member.getName())
                 .profileImage(member.getProfileImage())
+                .currentMember(member.getId() == currentMemberId)
                 .gender(member.getGender()).build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -91,8 +91,10 @@ public class AccompanyController {
 
     @GetMapping("/comments/{accompanyPostId}")
     public ResponseEntity<AccompanyCommentsResponse> getAccompanyPostComments(
-            @PathVariable Long accompanyPostId) {
-        return ResponseEntity.ok(accompanyService.getAccompanyComments(accompanyPostId));
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(
+                accompanyService.getAccompanyComments(accompanyPostId, customUserDetails.getId()));
     }
 
     @PostMapping("/posts/{accompanyPostId}")

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -8,6 +8,7 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
+import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
 import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -117,6 +118,15 @@ public class AccompanyController {
     @GetMapping("/posts/regions")
     public ResponseEntity<Map<String, Object>> getAccompanyPostRegions() {
         return ResponseEntity.ok(Map.of("regions", AccompanyRegionType.getNames()));
+    }
+
+    @GetMapping("/profile/{memberId}")
+    public ResponseEntity<MemberProfile> getMemberProfile(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        return ResponseEntity.ok(
+                accompanyService.getMemberProfile(memberId, customUserDetails.getId()));
     }
 
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -403,15 +403,21 @@ class AccompanyControllerTest {
                         responseFields(
                                 fieldWithPath("id").type(NUMBER).description("동행 구인글 id"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("memberInfo.id").type(NUMBER).description("작성자 id"),
-                                fieldWithPath("memberInfo.name").type(STRING).description("작성자 이름"),
-                                fieldWithPath("memberInfo.profileImage").type(STRING)
+                                fieldWithPath("memberProfile.id").type(NUMBER)
+                                        .description("작성자 id"),
+                                fieldWithPath("memberProfile.name").type(STRING)
+                                        .description("작성자 이름"),
+                                fieldWithPath("memberProfile.profileImage").type(STRING)
                                         .description("작성자 프로필 이미지 url"),
-                                fieldWithPath("memberInfo.gender").type(STRING)
+                                fieldWithPath("memberProfile.gender").type(STRING)
                                         .description("작성자 성별"),
-                                fieldWithPath("memberInfo.age").type(NUMBER).description("작성자 나이"),
-                                fieldWithPath("memberInfo.introduction").type(STRING)
+                                fieldWithPath("memberProfile.age").type(NUMBER)
+                                        .description("작성자 나이"),
+                                fieldWithPath("memberProfile.introduction").type(STRING)
                                         .description("작성자 소개"),
+                                fieldWithPath(
+                                        "memberProfile.currentMember").type(
+                                        BOOLEAN).description("본인 여부"),
                                 fieldWithPath("createdAt").type(STRING).description("생성 날짜"),
                                 fieldWithPath("updatedAt").type(STRING).description("수정 날짜"),
                                 fieldWithPath("viewCount").type(NUMBER).description("조회수"),
@@ -524,20 +530,25 @@ class AccompanyControllerTest {
                                         .description("생성 날짜"),
                                 fieldWithPath("accompanyCommentInfos[].updatedAt").type(STRING)
                                         .description("수정 날짜"),
-                                fieldWithPath("accompanyCommentInfos[].memberInfo.id").type(NUMBER)
+                                fieldWithPath("accompanyCommentInfos[].memberProfile.id").type(
+                                                NUMBER)
                                         .description("작성자 id"),
-                                fieldWithPath("accompanyCommentInfos[].memberInfo.name").type(
+                                fieldWithPath("accompanyCommentInfos[].memberProfile.name").type(
                                         STRING).description("작성자 이름"),
                                 fieldWithPath(
-                                        "accompanyCommentInfos[].memberInfo.profileImage").type(
+                                        "accompanyCommentInfos[].memberProfile.profileImage").type(
                                         STRING).description("작성자 프로필 이미지 url"),
-                                fieldWithPath("accompanyCommentInfos[].memberInfo.gender").type(
+                                fieldWithPath("accompanyCommentInfos[].memberProfile.gender").type(
                                         STRING).description("작성자 성별"),
-                                fieldWithPath("accompanyCommentInfos[].memberInfo.age").type(NUMBER)
+                                fieldWithPath("accompanyCommentInfos[].memberProfile.age").type(
+                                                NUMBER)
                                         .description("작성자 나이"),
                                 fieldWithPath(
-                                        "accompanyCommentInfos[].memberInfo.introduction").type(
-                                        STRING).description("작성자 소개")
+                                        "accompanyCommentInfos[].memberProfile.introduction").type(
+                                        STRING).description("작성자 소개"),
+                                fieldWithPath(
+                                        "accompanyCommentInfos[].memberProfile.currentMember").type(
+                                        BOOLEAN).description("본인 여부")
                         )
                 ));
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #9

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
특정 멤버 정보 조회 api 구현하였습니다.
- 기존에 구현해 둔 멤버 정보를 담는 클래스에 본인 여부 필드를 추가

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
