### PR TITLE
refactor #45: member 필드 중 name, nickname 명확화

### DIFF
--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsResponse.java
@@ -41,7 +41,7 @@ public class AccompanyPostsResponse {
                     .totalPeople(accompanyPost.getTotalPeople())
                     .createdAt(accompanyPost.getCreatedAt())
                     .updatedAt(accompanyPost.getUpdatedAt())
-                    .writer(accompanyPost.getMember().getName())
+                    .writer(accompanyPost.getMember().getNickname())
                     .viewCount(accompanyPost.getViewCount())
                     .commentCount(0L) // 임시
                     .build();

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/MemberProfile.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/MemberProfile.java
@@ -12,7 +12,7 @@ public class MemberProfile {
 
     private Long id;
 
-    private String name;
+    private String nickname;
 
     private String profileImage;
 
@@ -29,7 +29,7 @@ public class MemberProfile {
                 .id(member.getId())
                 .age(member.getAge())
                 .introduction(member.getIntroduction())
-                .name(member.getName())
+                .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
                 .currentMember(member.getId() == currentMemberId)
                 .gender(member.getGender()).build();

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/CustomOAuth2UserService.java
@@ -31,7 +31,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private Member saveOrUpdate(OAuth2UserInfo oAuth2UserInfo) {
         Member member = memberRepository.findByProviderIdAndIsActivatedIsTrue(
                         oAuth2UserInfo.getProviderId())
-                .map(entity -> entity.updateName(oAuth2UserInfo.getName()))
+                .map(entity -> entity.updateProfileImage(oAuth2UserInfo.getProfileImage()))
                 .orElse(oAuth2UserInfo.toEntity());
 
         return memberRepository.save(member);

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2LoginSuccessHandler.java
@@ -30,7 +30,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = tokenProvider.createAccessToken(oAuth2User.getProviderId(),
                 (List<GrantedAuthority>) oAuth2User.getAuthorities());
         String refreshToken = tokenProvider.createRefreshToken(oAuth2User.getProviderId());
-        Boolean isFirstLogin = oAuth2User.getMember().getBirthDate() == null;
+        Boolean isFirstLogin = oAuth2User.getMember().getNickname() == null;
         String uri = createURI(accessToken, refreshToken, isFirstLogin);
 
         getRedirectStrategy().sendRedirect(request, response, uri);

--- a/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/gogoring/dongoorami/global/oauth2/OAuth2UserInfo.java
@@ -10,14 +10,12 @@ public class OAuth2UserInfo {
 
     private final String providerId;
     private final String provider;
-    private final String name;
     private final String profileImage;
 
     @Builder
-    public OAuth2UserInfo(String providerId, String provider, String name, String profileImage) {
+    public OAuth2UserInfo(String providerId, String provider, String profileImage) {
         this.providerId = providerId;
         this.provider = provider;
-        this.name = name;
         this.profileImage = profileImage;
     }
 
@@ -40,7 +38,6 @@ public class OAuth2UserInfo {
         return OAuth2UserInfo.builder()
                 .providerId(attributes.get("id").toString())
                 .provider("kakao")
-                .name((String) kakaoProfile.get("nickname"))
                 .profileImage((String) kakaoProfile.get("profile_image_url"))
                 .build();
     }
@@ -49,7 +46,6 @@ public class OAuth2UserInfo {
         return OAuth2UserInfo.builder()
                 .providerId((String) attributes.get("sub"))
                 .provider("google")
-                .name((String) attributes.get("name"))
                 .profileImage((String) attributes.get("picture"))
                 .build();
     }
@@ -58,14 +54,12 @@ public class OAuth2UserInfo {
         return OAuth2UserInfo.builder()
                 .providerId((String) attributes.get("id"))
                 .provider("naver")
-                .name((String) attributes.get("name"))
                 .profileImage((String) attributes.get("profile_image"))
                 .build();
     }
 
     public Member toEntity() {
         return Member.builder()
-                .name(getName())
                 .profileImage(getProfileImage())
                 .provider(getProvider())
                 .providerId(getProviderId())

--- a/src/main/java/com/gogoring/dongoorami/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/member/application/MemberServiceImpl.java
@@ -56,7 +56,7 @@ public class MemberServiceImpl implements MemberService {
     public void signUp(MemberSignUpRequest memberSignUpRequest, Long memberId) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        member.updateNameAndGenderAndBirthDate(memberSignUpRequest.getNickname(),
+        member.updateNicknameAndGenderAndBirthDate(memberSignUpRequest.getNickname(),
                 memberSignUpRequest.getGender(), memberSignUpRequest.getBirthDate());
     }
 
@@ -103,7 +103,7 @@ public class MemberServiceImpl implements MemberService {
     public MemberInfoResponse updateMember(MemberUpdateRequest memberUpdateRequest, Long memberId) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-        member.updateNameAndIntroduction(memberUpdateRequest.getName(),
+        member.updateNicknameAndIntroduction(memberUpdateRequest.getNickname(),
                 memberUpdateRequest.getIntroduction());
 
         return MemberInfoResponse.of(member);

--- a/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
+++ b/src/main/java/com/gogoring/dongoorami/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.gogoring.dongoorami.member.domain;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import com.gogoring.dongoorami.member.exception.AlreadySignUpException;
 import com.gogoring.dongoorami.member.exception.MemberErrorCode;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,14 +30,18 @@ public class Member extends BaseEntity {
     private Long id;
 
     @ElementCollection(fetch = FetchType.EAGER)
+    @Column(nullable = false)
     private List<Role> roles;
 
-    private String name;
+    private String nickname;
 
+    @Column(nullable = false)
     private String profileImage;
 
+    @Column(nullable = false)
     private String provider;
 
+    @Column(nullable = false)
     private String providerId;
 
     private String gender;
@@ -45,11 +50,11 @@ public class Member extends BaseEntity {
 
     private String introduction;
 
+    @Column(nullable = false)
     private Integer manner;
 
     @Builder
-    public Member(String name, String profileImage, String provider, String providerId) {
-        this.name = name;
+    public Member(String profileImage, String provider, String providerId) {
         this.profileImage = profileImage;
         this.provider = provider;
         this.providerId = providerId;
@@ -73,29 +78,25 @@ public class Member extends BaseEntity {
                 : (LocalDate.now().getYear() - this.getBirthDate().getYear()) + 1;
     }
 
-    public Member updateName(String name) {
-        this.name = name;
+    public Member updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
         return this;
     }
 
-    public void updateProfileImage(String profileImage) {
-        this.profileImage = profileImage;
-    }
-
-    public void updateNameAndGenderAndBirthDate(String name, String gender, LocalDate birthDate) {
-        checkGenderAndBirthDateIsNull();
-        this.name = name;
+    public void updateNicknameAndGenderAndBirthDate(String nickname, String gender, LocalDate birthDate) {
+        checkIsNull();
+        this.nickname = nickname;
         this.gender = gender;
         this.birthDate = birthDate;
     }
 
-    public void updateNameAndIntroduction(String name, String introduction) {
-        this.name = name;
+    public void updateNicknameAndIntroduction(String nickname, String introduction) {
+        this.nickname = nickname;
         this.introduction = introduction;
     }
 
-    private void checkGenderAndBirthDateIsNull() {
-        if (gender != null || birthDate != null) {
+    private void checkIsNull() {
+        if (this.nickname != null || this.gender != null || this.birthDate != null) {
             throw new AlreadySignUpException(MemberErrorCode.ALREADY_SIGN_UP);
         }
     }

--- a/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/member/dto/request/MemberUpdateRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 public class MemberUpdateRequest {
 
     @NotBlank(message = "닉네임은 공백일 수 없습니다.")
-    private String name;
+    private String nickname;
 
     @NotBlank(message = "소개는 공백일 수 없습니다.")
     private String introduction;

--- a/src/main/java/com/gogoring/dongoorami/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/member/dto/response/MemberInfoResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class MemberInfoResponse {
 
-    private final String name;
+    private final String nickname;
 
     private final String profileImage;
 
@@ -20,9 +20,9 @@ public class MemberInfoResponse {
     private final Integer manner;
 
     @Builder
-    public MemberInfoResponse(String name, String profileImage, String gender, Integer age,
+    public MemberInfoResponse(String nickname, String profileImage, String gender, Integer age,
             String introduction, Integer manner) {
-        this.name = name;
+        this.nickname = nickname;
         this.profileImage = profileImage;
         this.gender = gender;
         this.age = age;
@@ -32,7 +32,7 @@ public class MemberInfoResponse {
 
     public static MemberInfoResponse of(Member member) {
         return MemberInfoResponse.builder()
-                .name(member.getName())
+                .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
                 .gender(member.getGender())
                 .age(member.getAge())

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -183,6 +183,7 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         memberRepository.save(member);
         String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
                 member.getRoles());
@@ -279,6 +280,7 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         memberRepository.save(member);
         String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
                 member.getRoles());
@@ -377,6 +379,7 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "여자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
@@ -405,8 +408,8 @@ class AccompanyControllerTest {
                                 fieldWithPath("title").type(STRING).description("제목"),
                                 fieldWithPath("memberProfile.id").type(NUMBER)
                                         .description("작성자 id"),
-                                fieldWithPath("memberProfile.name").type(STRING)
-                                        .description("작성자 이름"),
+                                fieldWithPath("memberProfile.nickname").type(STRING)
+                                        .description("작성자 닉네임"),
                                 fieldWithPath("memberProfile.profileImage").type(STRING)
                                         .description("작성자 프로필 이미지 url"),
                                 fieldWithPath("memberProfile.gender").type(STRING)
@@ -493,6 +496,7 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "여자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
@@ -533,8 +537,8 @@ class AccompanyControllerTest {
                                 fieldWithPath("accompanyCommentInfos[].memberProfile.id").type(
                                                 NUMBER)
                                         .description("작성자 id"),
-                                fieldWithPath("accompanyCommentInfos[].memberProfile.name").type(
-                                        STRING).description("작성자 이름"),
+                                fieldWithPath("accompanyCommentInfos[].memberProfile.nickname").type(
+                                        STRING).description("작성자 닉네임"),
                                 fieldWithPath(
                                         "accompanyCommentInfos[].memberProfile.profileImage").type(
                                         STRING).description("작성자 프로필 이미지 url"),
@@ -703,6 +707,7 @@ class AccompanyControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "여자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
@@ -728,8 +733,8 @@ class AccompanyControllerTest {
                         responseFields(
                                 fieldWithPath("id").type(NUMBER)
                                         .description("멤버 id"),
-                                fieldWithPath("name").type(
-                                        STRING).description("이름"),
+                                fieldWithPath("nickname").type(
+                                        STRING).description("닉네임"),
                                 fieldWithPath(
                                         "profileImage").type(
                                         STRING).description("프로필 이미지 url"),
@@ -760,11 +765,11 @@ class AccompanyControllerTest {
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
         Member member2 = Member.builder()
-                .name("김뭐뭐")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("hajkdflajkflajdklag")
                 .build();
+        ReflectionTestUtils.setField(member2, "nickname", "김뭐뭐");
         ReflectionTestUtils.setField(member2, "gender", "여자");
         ReflectionTestUtils.setField(member2, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member2, "introduction", "안녕하세요~");

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
@@ -55,7 +55,6 @@ class AccompanyPostRepositoryTest {
     void success_findAllByOrderByIdDesc() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -77,7 +76,6 @@ class AccompanyPostRepositoryTest {
     void success_findByIdLessThanOrderByIdDesc() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -103,7 +101,6 @@ class AccompanyPostRepositoryTest {
     void success_findByAccompanyPostFilterRequest() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -152,7 +149,6 @@ class AccompanyPostRepositoryTest {
     void success_findByAccompanyPostFilterRequest_given_purposes() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -204,7 +200,6 @@ class AccompanyPostRepositoryTest {
     void success_findByAccompanyPostFilterRequest_given_ages() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")

--- a/src/test/java/com/gogoring/dongoorami/global/customMockUser/WithCustomMockUser.java
+++ b/src/test/java/com/gogoring/dongoorami/global/customMockUser/WithCustomMockUser.java
@@ -8,8 +8,6 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 @WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
 public @interface WithCustomMockUser {
 
-    String name() default "김뫄뫄";
-
     String profileImage() default "image.png";
 
     String provider() default "kakao";

--- a/src/test/java/com/gogoring/dongoorami/global/customMockUser/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/gogoring/dongoorami/global/customMockUser/WithCustomMockUserSecurityContextFactory.java
@@ -14,13 +14,11 @@ public class WithCustomMockUserSecurityContextFactory implements
     @Override
     public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
         Long id = 1L;
-        String name = annotation.name();
         String profileImage = annotation.profileImage();
         String provider = annotation.provider();
         String providerId = annotation.providerId();
 
         Member member = Member.builder()
-                .name(name)
                 .profileImage(profileImage)
                 .provider(provider)
                 .providerId(providerId)

--- a/src/test/java/com/gogoring/dongoorami/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/member/presentation/MemberControllerTest.java
@@ -74,7 +74,6 @@ public class MemberControllerTest {
     void success_reissueToken() throws Exception {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -287,7 +286,7 @@ public class MemberControllerTest {
                 member.getRoles());
 
         MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest();
-        ReflectionTestUtils.setField(memberUpdateRequest, "name", "이롸롸");
+        ReflectionTestUtils.setField(memberUpdateRequest, "nickname", "이롸롸");
         ReflectionTestUtils.setField(memberUpdateRequest, "introduction", "안녕하세요~");
 
         // when
@@ -300,7 +299,7 @@ public class MemberControllerTest {
 
         // then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value(memberUpdateRequest.getName()))
+                .andExpect(jsonPath("$.nickname").value(memberUpdateRequest.getNickname()))
                 .andExpect(jsonPath("$.profileImage").value(member.getProfileImage()))
                 .andExpect(jsonPath("$.gender").value(member.getGender()))
                 .andExpect(jsonPath("$.age").value(member.getAge()))
@@ -310,14 +309,14 @@ public class MemberControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
                                         .description("닉네임"),
                                 fieldWithPath("introduction").type(JsonFieldType.STRING)
                                         .description("한줄 소개")
                         ),
                         responseFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING)
-                                        .description("이름"),
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("닉네임"),
                                 fieldWithPath("profileImage").type(JsonFieldType.STRING)
                                         .description("프로필 이미지 주소"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING)
@@ -341,6 +340,7 @@ public class MemberControllerTest {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
+        ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "남자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2000, 12, 31));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
@@ -357,7 +357,7 @@ public class MemberControllerTest {
 
         // then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value(member.getName()))
+                .andExpect(jsonPath("$.nickname").value(member.getNickname()))
                 .andExpect(jsonPath("$.profileImage").value(member.getProfileImage()))
                 .andExpect(jsonPath("$.gender").value(member.getGender()))
                 .andExpect(jsonPath("$.age").value(member.getAge()))
@@ -367,8 +367,8 @@ public class MemberControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING)
-                                        .description("이름"),
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("닉네임"),
                                 fieldWithPath("profileImage").type(JsonFieldType.STRING)
                                         .description("프로필 이미지 주소"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING)

--- a/src/test/java/com/gogoring/dongoorami/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/member/repository/MemberRepositoryTest.java
@@ -40,7 +40,6 @@ public class MemberRepositoryTest {
     void success_findByIdAndIsActivatedIsTrue() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
@@ -61,7 +60,6 @@ public class MemberRepositoryTest {
     void success_findByProviderIdAndIsActivatedIsTrue() {
         // given
         Member member = Member.builder()
-                .name("김뫄뫄")
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #45 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- member 필드에서 nickname, name이 혼용되어 사용되던 부분들을 nickname으로 통일하였습니다.
- 소셜 로그인 시 가져오는 정보에서 닉네임을 제외하게 되면서 일부 로직 수정되었습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
