### PR TITLE
feat #43: 동행 신청 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -207,6 +207,15 @@ include::{snippets}/AccompanyControllerTest/getMemberProfile/path-parameters.ado
 include::{snippets}/AccompanyControllerTest/getMemberProfile/http-response.adoc[]
 include::{snippets}/AccompanyControllerTest/getMemberProfile/response-fields.adoc[]
 
+=== 동행 신청
+
+.Request
+include::{snippets}/AccompanyControllerTest/applyAccompany/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/applyAccompany/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/applyAccompany/http-response.adoc[]
+
 == 공연 API
 === 공연 후기 작성
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -21,7 +21,8 @@ public interface AccompanyService {
     AccompanyPostResponse getAccompanyPost(Long currentMemberId, Long accompanyPostId);
 
     Long createAccompanyComment(Long accompanyPostId,
-            AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId);
+            AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId,
+            Boolean isAccompanyApplyComment);
 
     AccompanyCommentsResponse getAccompanyComments(Long accompanyPostId, Long currentMemberId);
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -38,4 +38,6 @@ public interface AccompanyService {
             AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId);
 
     void deleteAccompanyComment(Long accompanyCommentId, Long currentMemberId);
+
+    Long createAccompanyApplyComment(Long accompanyPostId, Long currentMemberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -72,7 +72,8 @@ public class AccompanyServiceImpl implements AccompanyService {
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
                         AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
         accompanyPost.increaseViewCount();
-        Long waitingCount = accompanyCommentRepository.countByIsActivatedIsTrueAndIsAccompanyApplyCommentTrue();
+        Long waitingCount = accompanyCommentRepository.countByAccompanyPostIdAndIsActivatedIsTrueAndIsAccompanyApplyCommentTrue(
+                accompanyPostId);
 
         return AccompanyPostResponse.of(accompanyPost, waitingCount,
                 MemberProfile.of(accompanyPost.getMember(), currentMemberId));
@@ -176,7 +177,7 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     @Override
     public Long createAccompanyApplyComment(Long accompanyPostId, Long currentMemberId) {
-        checkDuplicatedAccompanyApply(currentMemberId);
+        checkDuplicatedAccompanyApply(accompanyPostId, currentMemberId);
         return createAccompanyComment(accompanyPostId,
                 AccompanyCommentRequest.createAccompanyApplyCommentRequest(),
                 currentMemberId, true);
@@ -188,8 +189,9 @@ public class AccompanyServiceImpl implements AccompanyService {
         }
     }
 
-    private void checkDuplicatedAccompanyApply(Long memberId) {
-        if (accompanyCommentRepository.existsByMemberIdAndIsAccompanyApplyCommentTrue(memberId)) {
+    private void checkDuplicatedAccompanyApply(Long accompanyPostId, Long memberId) {
+        if (accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
+                accompanyPostId, memberId)) {
             throw new DuplicatedAccompanyApplyException(
                     AccompanyErrorCode.DUPLICATED_ACCOMPANY_APPLY);
         }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -78,14 +78,16 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     @Override
     public Long createAccompanyComment(Long accompanyPostId,
-            AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId) {
+            AccompanyCommentRequest accompanyCommentRequest, Long currentMemberId,
+            Boolean isAccompanyApplyComment) {
         Member member = memberRepository.findByIdAndIsActivatedIsTrue(currentMemberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
         AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
                         accompanyPostId)
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
                         AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
-        AccompanyComment accompanyComment = accompanyCommentRequest.toEntity(member);
+        AccompanyComment accompanyComment = accompanyCommentRequest.toEntity(member,
+                isAccompanyApplyComment);
         accompanyPost.addAccompanyComment(accompanyComment);
         accompanyCommentRepository.save(accompanyComment);
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -11,6 +11,7 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
+import com.gogoring.dongoorami.accompany.exception.AccompanyApplyCommentModificationNotAllowedException;
 import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
 import com.gogoring.dongoorami.accompany.exception.AccompanyPostNotFoundException;
 import com.gogoring.dongoorami.accompany.exception.DuplicatedAccompanyApplyException;
@@ -161,6 +162,7 @@ public class AccompanyServiceImpl implements AccompanyService {
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
                         AccompanyErrorCode.ACCOMPANY_POST_COMMENT_NOT_FOUND));
         checkMemberIsWriter(accompanyComment.getMember().getId(), currentMemberId);
+        checkIsAccompanyApplyComment(accompanyComment.getIsAccompanyApplyComment());
         accompanyComment.updateContent(accompanyCommentRequest.getContent());
     }
 
@@ -194,6 +196,13 @@ public class AccompanyServiceImpl implements AccompanyService {
                 accompanyPostId, memberId)) {
             throw new DuplicatedAccompanyApplyException(
                     AccompanyErrorCode.DUPLICATED_ACCOMPANY_APPLY);
+        }
+    }
+
+    private void checkIsAccompanyApplyComment(Boolean isAccompanyApplyComment) {
+        if (Boolean.TRUE.equals(isAccompanyApplyComment)) {
+            throw new AccompanyApplyCommentModificationNotAllowedException(
+                    AccompanyErrorCode.ACCOMPANY_APPLY_COMMENT_MODIFICATION_NOT_ALLOWED);
         }
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyComment.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyComment.java
@@ -25,11 +25,13 @@ public class AccompanyComment extends BaseEntity {
     @ManyToOne
     private Member member;
     private String content;
+    private Boolean isAccompanyApplyComment;
 
     @Builder
-    public AccompanyComment(Member member, String content) {
+    public AccompanyComment(Member member, String content, Boolean isAccompanyApplyComment) {
         this.member = member;
         this.content = content;
+        this.isAccompanyApplyComment = isAccompanyApplyComment;
     }
 
     public void setAccompanyPost(AccompanyPost accompanyPost) {

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyCommentRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyCommentRequest.java
@@ -18,9 +18,11 @@ public class AccompanyCommentRequest {
     private String content;
 
     public AccompanyComment toEntity(Member member) {
+    public AccompanyComment toEntity(Member member, Boolean isAccompanyApplyComment) {
         return AccompanyComment.builder()
                 .member(member)
                 .content(content)
+                .isAccompanyApplyComment(isAccompanyApplyComment)
                 .build();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyCommentRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyCommentRequest.java
@@ -17,7 +17,10 @@ public class AccompanyCommentRequest {
     @NotBlank(message = "content는 공백일 수 없습니다.")
     private String content;
 
-    public AccompanyComment toEntity(Member member) {
+    public static AccompanyCommentRequest createAccompanyApplyCommentRequest() {
+        return new AccompanyCommentRequest("동행 신청합니다!");
+    }
+
     public AccompanyComment toEntity(Member member, Boolean isAccompanyApplyComment) {
         return AccompanyComment.builder()
                 .member(member)

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyCommentsResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyCommentsResponse.java
@@ -21,6 +21,7 @@ public class AccompanyCommentsResponse {
         private Long id;
         private MemberProfile memberProfile;
         private String content;
+        private Boolean isAccompanyApplyComment;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
@@ -30,6 +31,7 @@ public class AccompanyCommentsResponse {
                     .id(accompanyComment.getId())
                     .memberProfile(MemberProfile.of(accompanyComment.getMember(), currentMemberId))
                     .content(accompanyComment.getContent())
+                    .isAccompanyApplyComment(accompanyComment.getIsAccompanyApplyComment())
                     .createdAt(accompanyComment.getCreatedAt())
                     .updatedAt(accompanyComment.getUpdatedAt())
                     .build();

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
@@ -38,7 +38,7 @@ public class AccompanyPostResponse {
     private Boolean isWriter;
     private List<String> purposes;
 
-    public static AccompanyPostResponse of(AccompanyPost accompanyPost,
+    public static AccompanyPostResponse of(AccompanyPost accompanyPost, Long waitingCount,
             MemberProfile memberProfile) {
         return AccompanyPostResponse.builder()
                 .id(accompanyPost.getId())
@@ -58,7 +58,7 @@ public class AccompanyPostResponse {
                 .endAge(accompanyPost.getEndAge())
                 .startDate(accompanyPost.getStartDate())
                 .endDate(accompanyPost.getEndDate())
-                .waitingCount(0L) // 임시
+                .waitingCount(waitingCount)
                 .content(accompanyPost.getContent())
                 .images(accompanyPost.getImages())
                 .isWish(true) // 임시

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyCommentModificationNotAllowedException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyCommentModificationNotAllowedException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AccompanyApplyCommentModificationNotAllowedException extends RuntimeException {
+
+    private final String errorCode;
+
+    public AccompanyApplyCommentModificationNotAllowedException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyNotAllowedForWriterException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyNotAllowedForWriterException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AccompanyApplyNotAllowedForWriterException extends RuntimeException {
+
+    private final String errorCode;
+
+    public AccompanyApplyNotAllowedForWriterException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -15,5 +15,6 @@ public enum AccompanyErrorCode {
     ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다."),
     DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다."),
     ACCOMPANY_APPLY_COMMENT_MODIFICATION_NOT_ALLOWED("동행 신청 댓글은 수정이 불가능 합니다."),
+    ACCOMPANY_APPLY_NOT_ALLOWED_FOR_WRITER("작성자는 동행 신청이 불가능 합니다.");
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -12,7 +12,7 @@ public enum AccompanyErrorCode {
     INVALID_REGION_TYPE("유효하지 않은 지역입니다."),
     INVALID_AGE_RANGE("시작 나이는 종료 나이보다 작거나 같아야 합니다."),
     INCOMPLETE_AGE("시작 나이와 종료 나이 값은 함께 필요로 합니다."),
-    ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다.");
-
+    ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다."),
+    DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다.");
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -13,6 +13,7 @@ public enum AccompanyErrorCode {
     INVALID_AGE_RANGE("시작 나이는 종료 나이보다 작거나 같아야 합니다."),
     INCOMPLETE_AGE("시작 나이와 종료 나이 값은 함께 필요로 합니다."),
     ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다."),
-    DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다.");
+    DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다."),
+    ACCOMPANY_APPLY_COMMENT_MODIFICATION_NOT_ALLOWED("동행 신청 댓글은 수정이 불가능 합니다."),
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -74,4 +74,12 @@ public class AccompanyGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(AccompanyApplyCommentModificationNotAllowedException.class)
+    public ResponseEntity<ErrorResponse> catchAccompanyApplyCommentModificationNotAllowedException(
+            AccompanyApplyCommentModificationNotAllowedException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -82,4 +82,12 @@ public class AccompanyGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(AccompanyApplyNotAllowedForWriterException.class)
+    public ResponseEntity<ErrorResponse> catchAccompanyApplyNotAllowedForWriterException(
+            AccompanyApplyNotAllowedForWriterException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -66,4 +66,12 @@ public class AccompanyGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(DuplicatedAccompanyApplyException.class)
+    public ResponseEntity<ErrorResponse> catchDuplicatedAccompanyApplyException(
+            DuplicatedAccompanyApplyException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/DuplicatedAccompanyApplyException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/DuplicatedAccompanyApplyException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicatedAccompanyApplyException extends RuntimeException {
+
+    private final String errorCode;
+
+    public DuplicatedAccompanyApplyException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -152,4 +152,14 @@ public class AccompanyController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/{accompanyPostId}")
+    public ResponseEntity<Void> applyAccompany(
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        accompanyService.createAccompanyApplyComment(accompanyPostId,
+                customUserDetails.getId());
+        return ResponseEntity.created(URI.create("/api/v1/accompany/posts/" + accompanyPostId))
+                .build();
+    }
+
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -85,7 +85,7 @@ public class AccompanyController {
             @Valid @RequestBody AccompanyCommentRequest accompanyCommentRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         accompanyService.createAccompanyComment(accompanyPostId, accompanyCommentRequest,
-                customUserDetails.getId());
+                customUserDetails.getId(), false);
         return ResponseEntity.created(URI.create("/api/v1/accompany/posts/" + accompanyPostId))
                 .build();
     }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
@@ -8,7 +8,9 @@ public interface AccompanyCommentRepository extends JpaRepository<AccompanyComme
 
     Optional<AccompanyComment> findByIdAndIsActivatedIsTrue(Long id);
 
-    Long countByIsActivatedIsTrueAndIsAccompanyApplyCommentTrue();
+    Long countByAccompanyPostIdAndIsActivatedIsTrueAndIsAccompanyApplyCommentTrue(
+            Long accompanyPostId);
 
-    boolean existsByMemberIdAndIsAccompanyApplyCommentTrue(Long memberId);
+    boolean existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(Long accompanyPostId,
+            Long memberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccompanyCommentRepository extends JpaRepository<AccompanyComment, Long> {
 
     Optional<AccompanyComment> findByIdAndIsActivatedIsTrue(Long id);
+
+    Long countByIsActivatedIsTrueAndIsAccompanyApplyCommentTrue();
+
+    boolean existsByMemberIdAndIsAccompanyApplyCommentTrue(Long memberId);
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/AccompanyDataFactory.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/AccompanyDataFactory.java
@@ -1,0 +1,101 @@
+package com.gogoring.dongoorami.accompany;
+
+import com.gogoring.dongoorami.accompany.domain.AccompanyComment;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
+import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
+import com.gogoring.dongoorami.member.domain.Member;
+import java.io.FileInputStream;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class AccompanyDataFactory {
+
+    @Value("${cloud.aws.s3.default-image-url}")
+    static private String defaultImageUrl;
+
+    static public List<MockMultipartFile> createMockMultipartFiles(int size) throws Exception {
+        List<MockMultipartFile> images = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            images.add(new MockMultipartFile("images", "김영한.JPG",
+                    MediaType.MULTIPART_FORM_DATA_VALUE,
+                    new FileInputStream("src/test/resources/김영한.JPG")));
+        }
+
+        return images;
+    }
+
+    static public List<String> createImageUrls(int size) {
+        List<String> imageUrls = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            imageUrls.add(defaultImageUrl);
+        }
+
+        return imageUrls;
+    }
+
+    static public List<AccompanyComment> createAccompanyComment(Member member, int size) {
+        List<AccompanyComment> accompanyComments = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            accompanyComments.add(
+                    AccompanyComment.builder().member(member).content("가는 길만 동행해도 괜찮을까요!?")
+                            .isAccompanyApplyComment(false)
+                            .build());
+        }
+
+        return accompanyComments;
+    }
+
+    static public List<AccompanyPost> createAccompanyPosts(Member member, int size) {
+        List<AccompanyPost> accompanyPosts = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            accompanyPosts.add(AccompanyPost.builder()
+                    .member(member)
+                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
+                    .concertPlace("KSPO DOME")
+                    .startDate(LocalDate.of(2024, 3, 22))
+                    .endDate(LocalDate.of(2024, 3, 22))
+                    .title("서울 같이 갈 울싼 사람 구합니다~~")
+                    .gender("여")
+                    .region("수도권(경기, 인천 포함)")
+                    .content("같이 올라갈 사람 구해요~")
+                    .startAge(23L)
+                    .endAge(37L)
+                    .totalPeople(2L)
+                    .purposes(Arrays.asList(AccompanyPurposeType.ACCOMMODATION,
+                            AccompanyPurposeType.TRANSPORTATION)).build());
+        }
+
+        return accompanyPosts;
+    }
+
+    static public List<AccompanyPost> createAccompanyPosts(Member member, int size,
+            AccompanyPostFilterRequest accompanyPostFilterRequest) {
+        List<AccompanyPost> accompanyPosts = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            accompanyPosts.add(AccompanyPost.builder()
+                    .member(member)
+                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
+                    .concertPlace(accompanyPostFilterRequest.getConcertPlace())
+                    .startDate(LocalDate.of(2024, 3, 22))
+                    .endDate(LocalDate.of(2024, 3, 22))
+                    .title("서울 같이 갈 울싼 사람 구합니다~~")
+                    .gender(accompanyPostFilterRequest.getGender())
+                    .region(accompanyPostFilterRequest.getRegion())
+                    .content("같이 올라갈 사람 구해요~")
+                    .startAge(accompanyPostFilterRequest.getStartAge())
+                    .endAge(accompanyPostFilterRequest.getEndAge())
+                    .totalPeople(accompanyPostFilterRequest.getTotalPeople())
+                    .purposes(accompanyPostFilterRequest.getPurposes().stream().map(
+                            AccompanyPurposeType::getValue).toList()).build());
+        }
+
+        return accompanyPosts;
+    }
+
+}

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -528,7 +528,9 @@ class AccompanyControllerTest {
                                         .description("댓글 id"),
                                 fieldWithPath("accompanyCommentInfos[].content").type(STRING)
                                         .description("내용"),
-                                fieldWithPath("accompanyCommentInfos[].isAccompanyApplyComment").type(BOOLEAN)
+                                fieldWithPath(
+                                        "accompanyCommentInfos[].isAccompanyApplyComment").type(
+                                                BOOLEAN)
                                         .description("동행 신청 댓글 여부"),
                                 fieldWithPath("accompanyCommentInfos[].createdAt").type(STRING)
                                         .description("생성 날짜"),

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -1,5 +1,8 @@
 package com.gogoring.dongoorami.accompany.presentation;
 
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyComment;
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyPosts;
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createMockMultipartFiles;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -42,10 +45,8 @@ import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import com.gogoring.dongoorami.global.jwt.TokenProvider;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
-import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -53,7 +54,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -87,9 +87,6 @@ class AccompanyControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Value("${cloud.aws.s3.default-image-url}")
-    private String defaultImageUrl;
 
     @BeforeEach
     void setUp() {
@@ -872,82 +869,7 @@ class AccompanyControllerTest {
                 ));
     }
 
-    private List<AccompanyPost> createAccompanyPosts(Member member, int size) throws Exception {
-        List<AccompanyPost> accompanyPosts = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            accompanyPosts.add(AccompanyPost.builder()
-                    .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace("KSPO DOME")
-                    .startDate(LocalDate.of(2024, 3, 22))
-                    .endDate(LocalDate.of(2024, 3, 22))
-                    .title("서울 같이 갈 울싼 사람 구합니다~~")
-                    .gender("여")
-                    .region("수도권(경기, 인천 포함)")
-                    .content("같이 올라갈 사람 구해요~")
-                    .startAge(23L)
-                    .endAge(37L)
-                    .totalPeople(2L)
-                    .images(createImageUrls(2))
-                    .purposes(Arrays.asList(AccompanyPurposeType.ACCOMMODATION,
-                            AccompanyPurposeType.TRANSPORTATION)).build());
-        }
 
-        return accompanyPosts;
-    }
 
-    private List<AccompanyPost> createAccompanyPosts(Member member, int size,
-            AccompanyPostFilterRequest accompanyPostFilterRequest) {
-        List<AccompanyPost> accompanyPosts = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            accompanyPosts.add(AccompanyPost.builder()
-                    .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace(accompanyPostFilterRequest.getConcertPlace())
-                    .startDate(LocalDate.of(2024, 3, 22))
-                    .endDate(LocalDate.of(2024, 3, 22))
-                    .title("서울 같이 갈 울싼 사람 구합니다~~")
-                    .gender(accompanyPostFilterRequest.getGender())
-                    .region(accompanyPostFilterRequest.getRegion())
-                    .content("같이 올라갈 사람 구해요~")
-                    .startAge(accompanyPostFilterRequest.getStartAge())
-                    .endAge(accompanyPostFilterRequest.getEndAge())
-                    .totalPeople(accompanyPostFilterRequest.getTotalPeople())
-                    .purposes(accompanyPostFilterRequest.getPurposes().stream().map(
-                            AccompanyPurposeType::getValue).toList()).build());
-        }
-
-        return accompanyPosts;
-    }
-
-    private List<MockMultipartFile> createMockMultipartFiles(int size) throws Exception {
-        List<MockMultipartFile> images = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            images.add(new MockMultipartFile("images", "김영한.JPG",
-                    MediaType.MULTIPART_FORM_DATA_VALUE,
-                    new FileInputStream("src/test/resources/김영한.JPG")));
-        }
-
-        return images;
-    }
-
-    private List<String> createImageUrls(int size) {
-        List<String> imageUrls = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            imageUrls.add(defaultImageUrl);
-        }
-
-        return imageUrls;
-    }
-
-    private List<AccompanyComment> createAccompanyComment(Member member, int size) {
-        List<AccompanyComment> accompanyComments = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            accompanyComments.add(
-                    AccompanyComment.builder().member(member).content("가는 길만 동행해도 괜찮을까요!?")
-                            .build());
-        }
-
-        return accompanyComments;
     }
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -869,7 +869,35 @@ class AccompanyControllerTest {
                 ));
     }
 
+    @Test
+    @WithCustomMockUser
+    @DisplayName("동행 구인 신청을 할 수 있다.")
+    void applyAccompany() throws Exception {
+        // given
+        Member member = ((CustomUserDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal()).getMember();
+        memberRepository.save(member);
+        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
+                member.getRoles());
+        AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, 1)).get(0);
 
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/accompanies/{accompanyPostId}", accompanyPost.getId())
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
 
+        // then
+        resultActions.andExpect(status().isCreated())
+                .andDo(document("{ClassName}/applyAccompany",
+                        preprocessRequest(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("accompanyPostId").description("동행 구인글 id")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -879,15 +879,20 @@ class AccompanyControllerTest {
     @DisplayName("동행 구인 신청을 할 수 있다.")
     void applyAccompany() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
+        Member member1 = ((CustomUserDetails) SecurityContextHolder
                 .getContext()
                 .getAuthentication()
                 .getPrincipal()).getMember();
-        memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
+        Member member2 = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjghjgdslk")
+                .build();
+        memberRepository.saveAll(Arrays.asList(member1, member2));
+        String accessToken = tokenProvider.createAccessToken(member1.getProviderId(),
+                member1.getRoles());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 1)).get(0);
+                createAccompanyPosts(member2, 1)).get(0);
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -528,6 +528,8 @@ class AccompanyControllerTest {
                                         .description("댓글 id"),
                                 fieldWithPath("accompanyCommentInfos[].content").type(STRING)
                                         .description("내용"),
+                                fieldWithPath("accompanyCommentInfos[].isAccompanyApplyComment").type(BOOLEAN)
+                                        .description("동행 신청 댓글 여부"),
                                 fieldWithPath("accompanyCommentInfos[].createdAt").type(STRING)
                                         .description("생성 날짜"),
                                 fieldWithPath("accompanyCommentInfos[].updatedAt").type(STRING)
@@ -535,7 +537,8 @@ class AccompanyControllerTest {
                                 fieldWithPath("accompanyCommentInfos[].memberProfile.id").type(
                                                 NUMBER)
                                         .description("작성자 id"),
-                                fieldWithPath("accompanyCommentInfos[].memberProfile.nickname").type(
+                                fieldWithPath(
+                                        "accompanyCommentInfos[].memberProfile.nickname").type(
                                         STRING).description("작성자 닉네임"),
                                 fieldWithPath(
                                         "accompanyCommentInfos[].memberProfile.profileImage").type(

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.gogoring.dongoorami.accompany.repository;
+
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyComment;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.gogoring.dongoorami.accompany.dto.request.AccompanyCommentRequest;
+import com.gogoring.dongoorami.global.config.QueryDslConfig;
+import com.gogoring.dongoorami.member.domain.Member;
+import com.gogoring.dongoorami.member.repository.MemberRepository;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(QueryDslConfig.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class AccompanyCommentRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccompanyCommentRepository accompanyCommentRepository;
+
+    @BeforeEach
+    void setUp() {
+        accompanyCommentRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        accompanyCommentRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동행 댓글 신청 수를 조회할 수 있다.")
+    void success_countByIsActivatedIsTrueAndIsAccompanyApplyCommentTrue() {
+        // given
+        Member member1 = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        Member member2 = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        memberRepository.saveAll(Arrays.asList(member1, member2));
+        accompanyCommentRepository.saveAll(createAccompanyComment(member1, 7));
+        accompanyCommentRepository.saveAll(createAccompanyComment(member2, 7));
+        AccompanyCommentRequest accompanyCommentRequest = AccompanyCommentRequest.createAccompanyApplyCommentRequest();
+        accompanyCommentRepository.save(accompanyCommentRequest.toEntity(member1, true));
+        accompanyCommentRepository.save(accompanyCommentRequest.toEntity(member2, true));
+
+        // when
+        Long waitingCount = accompanyCommentRepository.countByIsActivatedIsTrueAndIsAccompanyApplyCommentTrue();
+
+        // then
+        assertThat(waitingCount, equalTo(2L));
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 동행 신청 여부를 조회할 수 있다. - 신청한 경우")
+    void success_existsByMemberIdAndIsAccompanyApplyCommentTrue_given_appliedMember() {
+        // given
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        memberRepository.save(member);
+        AccompanyCommentRequest accompanyCommentRequest = AccompanyCommentRequest.createAccompanyApplyCommentRequest();
+        accompanyCommentRepository.save(accompanyCommentRequest.toEntity(member, true));
+
+        // when
+        boolean isAccompanyApplied = accompanyCommentRepository.existsByMemberIdAndIsAccompanyApplyCommentTrue(
+                member.getId());
+
+        // then
+        assertThat(isAccompanyApplied, equalTo(true));
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 동행 신청 여부를 조회할 수 있다. - 신청하지 않은 경우")
+    void success_existsByMemberIdAndIsAccompanyApplyCommentTrue_given_notAppliedMember() {
+        // given
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        memberRepository.save(member);
+        AccompanyCommentRequest accompanyCommentRequest = AccompanyCommentRequest.createAccompanyApplyCommentRequest();
+        accompanyCommentRepository.save(accompanyCommentRequest.toEntity(member, false));
+
+        // when
+        boolean isAccompanyApplied = accompanyCommentRepository.existsByMemberIdAndIsAccompanyApplyCommentTrue(
+                member.getId());
+
+        // then
+        assertThat(isAccompanyApplied, equalTo(false));
+    }
+}

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
@@ -75,7 +75,7 @@ class AccompanyCommentRepositoryTest {
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
                 createAccompanyPosts(member1, 1)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
-        accompanyComments.addAll(createAccompanyComment(member2, 3));
+        accompanyComments.addAll(createAccompanyComment(member1, 3));
         accompanyComments.add(AccompanyCommentRequest.createAccompanyApplyCommentRequest()
                 .toEntity(member2, true));
         accompanyComments.add(AccompanyCommentRequest.createAccompanyApplyCommentRequest()
@@ -95,25 +95,30 @@ class AccompanyCommentRepositoryTest {
     @DisplayName("특정 멤버의 동행 신청 여부를 조회할 수 있다. - 신청한 경우")
     void success_existsByMemberIdAndIsAccompanyApplyCommentTrue_given_appliedMember() {
         // given
-        Member member = Member.builder()
+        Member member1 = Member.builder()
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
                 .build();
-        memberRepository.save(member);
+        Member member2 = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        memberRepository.saveAll(Arrays.asList(member1, member2));
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 1)).get(0);
+                createAccompanyPosts(member1, 1)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
-        accompanyComments.addAll(createAccompanyComment(member, 3));
+        accompanyComments.addAll(createAccompanyComment(member1, 3));
         accompanyComments.add(AccompanyCommentRequest.createAccompanyApplyCommentRequest()
-                .toEntity(member, true));
+                .toEntity(member2, true));
         accompanyComments.stream().forEach(accompanyPost::addAccompanyComment);
         accompanyCommentRepository.saveAll(accompanyComments);
 
         // when
         boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
                 accompanyPost.getId(),
-                member.getId());
+                member2.getId());
 
         // then
         assertThat(isAccompanyApplied, equalTo(true));
@@ -123,25 +128,30 @@ class AccompanyCommentRepositoryTest {
     @DisplayName("특정 멤버의 동행 신청 여부를 조회할 수 있다. - 신청하지 않은 경우")
     void success_existsByMemberIdAndIsAccompanyApplyCommentTrue_given_notAppliedMember() {
         // given
-        Member member = Member.builder()
+        Member member1 = Member.builder()
                 .profileImage("image.png")
                 .provider("kakao")
                 .providerId("alsjkghlaskdjgh")
                 .build();
-        memberRepository.save(member);
+        Member member2 = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjgh")
+                .build();
+        memberRepository.saveAll(Arrays.asList(member1, member2));
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 1)).get(0);
+                createAccompanyPosts(member1, 1)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
-        accompanyComments.addAll(createAccompanyComment(member, 3));
+        accompanyComments.addAll(createAccompanyComment(member2, 3));
         accompanyComments.add(
-                new AccompanyCommentRequest("가는 길만 동행해도 괜찮을까요!?").toEntity(member, false));
+                new AccompanyCommentRequest("가는 길만 동행해도 괜찮을까요!?").toEntity(member2, false));
         accompanyComments.stream().forEach(accompanyPost::addAccompanyComment);
         accompanyCommentRepository.saveAll(accompanyComments);
 
         // when
         boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
                 accompanyPost.getId(),
-                member.getId());
+                member2.getId());
 
         // then
         assertThat(isAccompanyApplied, equalTo(false));

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
@@ -11,8 +11,6 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
 import com.gogoring.dongoorami.global.config.QueryDslConfig;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -246,53 +244,6 @@ class AccompanyPostRepositoryTest {
                         .map(accompanyPost -> isAccompanyPostEqualsAccompanyPostFilterRequest(
                                 accompanyPost, accompanyPostFilterRequest3))
                         .toList(), everyItem(equalTo(true)));
-    }
-
-    private List<AccompanyPost> createAccompanyPosts(Member member, int size) {
-        List<AccompanyPost> accompanyPosts = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            accompanyPosts.add(AccompanyPost.builder()
-                    .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace("KSPO DOME")
-                    .startDate(LocalDate.of(2024, 3, 22))
-                    .endDate(LocalDate.of(2024, 3, 22))
-                    .title("서울 같이 갈 울싼 사람 구합니다~~")
-                    .gender("여")
-                    .region("수도권(경기, 인천 포함)")
-                    .content("같이 올라갈 사람 구해요~")
-                    .startAge(23L)
-                    .endAge(37L)
-                    .totalPeople(2L)
-                    .purposes(Arrays.asList(AccompanyPurposeType.ACCOMMODATION,
-                            AccompanyPurposeType.TRANSPORTATION)).build());
-        }
-
-        return accompanyPosts;
-    }
-
-    private List<AccompanyPost> createAccompanyPosts(Member member, int size,
-            AccompanyPostFilterRequest accompanyPostFilterRequest) {
-        List<AccompanyPost> accompanyPosts = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            accompanyPosts.add(AccompanyPost.builder()
-                    .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace(accompanyPostFilterRequest.getConcertPlace())
-                    .startDate(LocalDate.of(2024, 3, 22))
-                    .endDate(LocalDate.of(2024, 3, 22))
-                    .title("서울 같이 갈 울싼 사람 구합니다~~")
-                    .gender(accompanyPostFilterRequest.getGender())
-                    .region(accompanyPostFilterRequest.getRegion())
-                    .content("같이 올라갈 사람 구해요~")
-                    .startAge(accompanyPostFilterRequest.getStartAge())
-                    .endAge(accompanyPostFilterRequest.getEndAge())
-                    .totalPeople(accompanyPostFilterRequest.getTotalPeople())
-                    .purposes(accompanyPostFilterRequest.getPurposes().stream().map(
-                            AccompanyPurposeType::getValue).toList()).build());
-        }
-
-        return accompanyPosts;
     }
 
     private boolean isAccompanyPostEqualsAccompanyPostFilterRequest(AccompanyPost accompanyPost,

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.gogoring.dongoorami.accompany.repository;
 
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyPosts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;

--- a/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
@@ -1,7 +1,7 @@
 package com.gogoring.dongoorami.concert.presentation;
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;

--- a/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
@@ -1,9 +1,8 @@
 package com.gogoring.dongoorami.concert.presentation;
 
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;

--- a/src/test/java/com/gogoring/dongoorami/concert/repository/ConcertRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/repository/ConcertRepositoryTest.java
@@ -44,7 +44,8 @@ public class ConcertRepositoryTest {
 
         // when
         Concert savedConcert = concertRepository.findByIdAndIsActivatedIsTrue(concert.getId())
-                .orElseThrow(() -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
+                .orElseThrow(
+                        () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
 
         // then
         assertThat(savedConcert.getId()).isEqualTo(concert.getId());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #43

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
3/11(월) 회의에서 동행 신청 버튼 클릭 시, 동행 댓글이 추가되도록 논의한 부분 반영하여 동행 신청 api를 구현하였습니다.
- AccompanyComment에 동행 신청 댓글 여부 isAccompanyApplyComment 추가
- 동행 신청 댓글 여부 필드를 기반으로 대기자 수 계산 및 중복 신청 예외 처리
- 동행 신청 댓글의 경우 수정이 불가하여, 프론트 측에서 판별할 수 있도록 댓글 반환 dto에 동행 신청 댓글 여부 isAccompanyApplyComment 추가

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
