### PR TITLE
refactor, feat #55: 동행 구인글 작성 api 수정 및 키워드 기반 공연 목록 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -268,3 +268,13 @@ include::{snippets}/ConcertControllerTest/deleteConcertReview/path-parameters.ad
 
 .Response
 include::{snippets}/ConcertControllerTest/deleteConcertReview/http-response.adoc[]
+
+=== 공연 목록 키워드로 조회(동행 구인글 작성 중 공연 목록 검색 시 사용)
+
+.Request
+include::{snippets}/ConcertControllerTest/getConcertsByKeyword/http-request.adoc[]
+include::{snippets}/ConcertControllerTest/getConcertsByKeyword/query-parameters.adoc[]
+
+.Response
+include::{snippets}/ConcertControllerTest/getConcertsByKeyword/http-response.adoc[]
+include::{snippets}/ConcertControllerTest/getConcertsByKeyword/response-fields.adoc[]

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -11,7 +11,7 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
-import com.gogoring.dongoorami.accompany.exception.AccompanyApplyCommentModificationNotAllowedException;
+import com.gogoring.dongoorami.accompany.exception.AccompanyApplyCommentModifyDeniedException;
 import com.gogoring.dongoorami.accompany.exception.AccompanyApplyNotAllowedForWriterException;
 import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
 import com.gogoring.dongoorami.accompany.exception.AccompanyPostNotFoundException;
@@ -207,8 +207,8 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     private void checkIsAccompanyApplyComment(Boolean isAccompanyApplyComment) {
         if (Boolean.TRUE.equals(isAccompanyApplyComment)) {
-            throw new AccompanyApplyCommentModificationNotAllowedException(
-                    AccompanyErrorCode.ACCOMPANY_APPLY_COMMENT_MODIFICATION_NOT_ALLOWED);
+            throw new AccompanyApplyCommentModifyDeniedException(
+                    AccompanyErrorCode.ACCOMPANY_APPLY_COMMENT_MODIFY_DENIED);
         }
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -38,6 +38,7 @@ public class AccompanyServiceImpl implements AccompanyService {
     private final AccompanyPostRepository accompanyPostRepository;
     private final AccompanyCommentRepository accompanyCommentRepository;
     private final MemberRepository memberRepository;
+    private final ConcertRepository concertRepository;
     private final S3ImageUtil s3ImageUtil;
 
     @Override
@@ -47,8 +48,12 @@ public class AccompanyServiceImpl implements AccompanyService {
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
         List<String> imageUrls = s3ImageUtil.putObjects(images,
                 ImageType.ACCOMPANY_POST);
+        Concert concert = concertRepository.findByIdAndIsActivatedIsTrue(
+                accompanyPostRequest.getConcertId()).orElseThrow(
+                () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
 
-        return accompanyPostRepository.save(accompanyPostRequest.toEntity(member, imageUrls))
+        return accompanyPostRepository.save(
+                        accompanyPostRequest.toEntity(concert, member, imageUrls))
                 .getId();
     }
 
@@ -127,7 +132,11 @@ public class AccompanyServiceImpl implements AccompanyService {
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
         List<String> imageUrls = s3ImageUtil.putObjects(images,
                 ImageType.ACCOMPANY_POST);
-        accompanyPost.update(accompanyPostRequest.toEntity(member, imageUrls), currentMemberId);
+        Concert concert = concertRepository.findByIdAndIsActivatedIsTrue(
+                accompanyPostRequest.getConcertId()).orElseThrow(
+                () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
+        accompanyPost.update(accompanyPostRequest.toEntity(concert, member, imageUrls),
+                currentMemberId);
         s3ImageUtil.deleteObjects(accompanyPost.getImages(), ImageType.ACCOMPANY_POST);
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -18,6 +18,10 @@ import com.gogoring.dongoorami.accompany.exception.AccompanyPostNotFoundExceptio
 import com.gogoring.dongoorami.accompany.exception.DuplicatedAccompanyApplyException;
 import com.gogoring.dongoorami.accompany.repository.AccompanyCommentRepository;
 import com.gogoring.dongoorami.accompany.repository.AccompanyPostRepository;
+import com.gogoring.dongoorami.concert.domain.Concert;
+import com.gogoring.dongoorami.concert.exception.ConcertErrorCode;
+import com.gogoring.dongoorami.concert.exception.ConcertNotFoundException;
+import com.gogoring.dongoorami.concert.repository.ConcertRepository;
 import com.gogoring.dongoorami.global.util.ImageType;
 import com.gogoring.dongoorami.global.util.S3ImageUtil;
 import com.gogoring.dongoorami.member.domain.Member;

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyComment.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyComment.java
@@ -1,5 +1,7 @@
 package com.gogoring.dongoorami.accompany.domain;
 
+import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
+import com.gogoring.dongoorami.accompany.exception.OnlyWriterCanModifyException;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.persistence.Entity;
@@ -38,7 +40,19 @@ public class AccompanyComment extends BaseEntity {
         this.accompanyPost = accompanyPost;
     }
 
-    public void updateContent(String content) {
+    public void updateContent(String content, Long memberId) {
+        checkIsWriter(memberId);
         this.content = content;
+    }
+
+    public void updateIsActivatedFalse(Long memberId) {
+        checkIsWriter(memberId);
+        updateIsActivatedFalse();
+    }
+
+    private void checkIsWriter(Long memberId) {
+        if (!this.member.getId().equals(memberId)) {
+            throw new OnlyWriterCanModifyException(AccompanyErrorCode.ONLY_WRITER_CAN_MODIFY);
+        }
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -4,6 +4,7 @@ import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
 import com.gogoring.dongoorami.accompany.exception.InvalidAccompanyPurposeTypeException;
 import com.gogoring.dongoorami.accompany.exception.InvalidAccompanyRegionTypeException;
 import com.gogoring.dongoorami.accompany.exception.OnlyWriterCanModifyException;
+import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.persistence.ElementCollection;
@@ -13,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
@@ -40,8 +42,9 @@ public class AccompanyPost extends BaseEntity {
     @ManyToOne
     private Member member;
     private String title;
-    private String concertName;
-    private String concertPlace;
+    @ManyToOne
+    @JoinColumn(name = "concert_id")
+    private Concert concert;
     @Enumerated(EnumType.STRING)
     private AccompanyRegionType region;
     private Long startAge;
@@ -58,14 +61,13 @@ public class AccompanyPost extends BaseEntity {
     private List<AccompanyPurposeType> purposes;
 
     @Builder
-    public AccompanyPost(Member member, String title, String concertName, String concertPlace,
+    public AccompanyPost(Member member, String title, Concert concert,
             String region, Long startAge, Long endAge, Long totalPeople, String gender,
             LocalDate startDate, LocalDate endDate, String content, List<String> images,
             List<AccompanyPurposeType> purposes) {
         this.member = member;
         this.title = title;
-        this.concertName = concertName;
-        this.concertPlace = concertPlace;
+        this.concert = concert;
         this.region = AccompanyRegionType.getValue(region);
         this.startAge = startAge;
         this.endAge = endAge;
@@ -90,8 +92,7 @@ public class AccompanyPost extends BaseEntity {
     public void update(AccompanyPost accompanyPost, Long memberId) {
         checkIsWriter(memberId);
         this.title = accompanyPost.title;
-        this.concertName = accompanyPost.concertName;
-        this.concertPlace = accompanyPost.concertPlace;
+        this.concert = accompanyPost.concert;
         this.region = accompanyPost.region;
         this.startAge = accompanyPost.startAge;
         this.endAge = accompanyPost.endAge;

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -92,6 +92,7 @@ public class AccompanyPost extends BaseEntity {
     public void update(AccompanyPost accompanyPost, Long memberId) {
         checkIsWriter(memberId);
         this.title = accompanyPost.title;
+        accompanyPost.getConcert().addAccompanyPost(accompanyPost);
         this.concert = accompanyPost.concert;
         this.region = accompanyPost.region;
         this.startAge = accompanyPost.startAge;

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -3,6 +3,7 @@ package com.gogoring.dongoorami.accompany.domain;
 import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
 import com.gogoring.dongoorami.accompany.exception.InvalidAccompanyPurposeTypeException;
 import com.gogoring.dongoorami.accompany.exception.InvalidAccompanyRegionTypeException;
+import com.gogoring.dongoorami.accompany.exception.OnlyWriterCanModifyException;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.persistence.ElementCollection;
@@ -86,7 +87,8 @@ public class AccompanyPost extends BaseEntity {
         accompanyComment.setAccompanyPost(this);
     }
 
-    public void update(AccompanyPost accompanyPost) {
+    public void update(AccompanyPost accompanyPost, Long memberId) {
+        checkIsWriter(memberId);
         this.title = accompanyPost.title;
         this.concertName = accompanyPost.concertName;
         this.concertPlace = accompanyPost.concertPlace;
@@ -100,6 +102,13 @@ public class AccompanyPost extends BaseEntity {
         this.content = accompanyPost.content;
         this.images = accompanyPost.images;
         this.purposes = accompanyPost.purposes;
+    }
+
+    private void checkIsWriter(Long memberId) {
+        if (!this.member.getId().equals(memberId)) {
+            throw new OnlyWriterCanModifyException(AccompanyErrorCode.ONLY_WRITER_CAN_MODIFY);
+
+        }
     }
 
     public enum RecruitmentStatusType {

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyPostRequest.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/request/AccompanyPostRequest.java
@@ -2,6 +2,9 @@ package com.gogoring.dongoorami.accompany.dto.request;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
+import com.gogoring.dongoorami.accompany.exception.AccompanyErrorCode;
+import com.gogoring.dongoorami.accompany.exception.AlreadyEndedConcertException;
+import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.member.domain.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,11 +25,9 @@ public class AccompanyPostRequest {
     @NotBlank(message = "title은 공백일 수 없습니다.")
     private String title;
 
-    @NotBlank(message = "concertName은 공백일 수 없습니다.")
-    private String concertName;
-
-    @NotBlank(message = "concertPlace은 공백일 수 없습니다.")
-    private String concertPlace;
+    @NotNull(message = "concertId은 공백일 수 없습니다.")
+    @Positive(message = "concertId은 양수만 가능합니다.")
+    private Long concertId;
 
     @NotBlank(message = "region은 공백일 수 없습니다.")
     private String region;
@@ -59,11 +60,12 @@ public class AccompanyPostRequest {
     @Size(min = 1, message = "purposes는 1개 이상 필요합니다.")
     private List<String> purposes;
 
-    public AccompanyPost toEntity(Member member, List<String> images) {
+    public AccompanyPost toEntity(Concert concert, Member member, List<String> images) {
+        checkAlreadyEndedConcert(concert.getEndLocalDate());
+
         return AccompanyPost.builder()
-                .concertName(concertName)
+                .concert(concert)
                 .gender(gender)
-                .concertPlace(concertPlace)
                 .content(content)
                 .endAge(endAge)
                 .endDate(endDate)
@@ -76,5 +78,11 @@ public class AccompanyPostRequest {
                 .images(images)
                 .purposes(purposes.stream().map(AccompanyPurposeType::getValue).toList())
                 .build();
+    }
+
+    private void checkAlreadyEndedConcert(LocalDate concertEndDate) {
+        if (concertEndDate.isBefore(LocalDate.now())) {
+            throw new AlreadyEndedConcertException(AccompanyErrorCode.ALREADY_ENDED_CONCERT);
+        }
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostResponse.java
@@ -44,7 +44,7 @@ public class AccompanyPostResponse {
                 .id(accompanyPost.getId())
                 .title(accompanyPost.getTitle())
                 .gender(accompanyPost.getGender())
-                .concertName(accompanyPost.getConcertName())
+                .concertName(accompanyPost.getConcert().getName())
                 .status(accompanyPost.getStatus().getName())
                 .totalPeople(accompanyPost.getTotalPeople())
                 .createdAt(accompanyPost.getCreatedAt())
@@ -52,7 +52,7 @@ public class AccompanyPostResponse {
                 .viewCount(accompanyPost.getViewCount())
                 .commentCount(0L) // 임시
                 .memberProfile(memberProfile)
-                .concertPlace(accompanyPost.getConcertPlace())
+                .concertPlace(accompanyPost.getConcert().getPlace())
                 .region(accompanyPost.getRegion().getName())
                 .startAge(accompanyPost.getStartAge())
                 .endAge(accompanyPost.getEndAge())

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsResponse.java
@@ -36,7 +36,7 @@ public class AccompanyPostsResponse {
                     .id(accompanyPost.getId())
                     .title(accompanyPost.getTitle())
                     .gender(accompanyPost.getGender())
-                    .concertName(accompanyPost.getConcertName())
+                    .concertName(accompanyPost.getConcert().getName())
                     .status(accompanyPost.getStatus().getName())
                     .totalPeople(accompanyPost.getTotalPeople())
                     .createdAt(accompanyPost.getCreatedAt())

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyCommentModifyDeniedException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyApplyCommentModifyDeniedException.java
@@ -3,11 +3,11 @@ package com.gogoring.dongoorami.accompany.exception;
 import lombok.Getter;
 
 @Getter
-public class AccompanyApplyCommentModificationNotAllowedException extends RuntimeException {
+public class AccompanyApplyCommentModifyDeniedException extends RuntimeException {
 
     private final String errorCode;
 
-    public AccompanyApplyCommentModificationNotAllowedException(AccompanyErrorCode errorCode) {
+    public AccompanyApplyCommentModifyDeniedException(AccompanyErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode.name();
     }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -15,6 +15,8 @@ public enum AccompanyErrorCode {
     ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다."),
     DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다."),
     ACCOMPANY_APPLY_COMMENT_MODIFY_DENIED("동행 신청 댓글은 수정이 불가능 합니다."),
-    ACCOMPANY_APPLY_NOT_ALLOWED_FOR_WRITER("작성자는 동행 신청이 불가능 합니다.");
+    ACCOMPANY_APPLY_NOT_ALLOWED_FOR_WRITER("작성자는 동행 신청이 불가능 합니다."),
+    ALREADY_ENDED_CONCERT("이미 종료된 공연입니다.");
+
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyErrorCode.java
@@ -14,7 +14,7 @@ public enum AccompanyErrorCode {
     INCOMPLETE_AGE("시작 나이와 종료 나이 값은 함께 필요로 합니다."),
     ACCOMPANY_POST_COMMENT_NOT_FOUND("게시글에 대한 댓글이 존재하지 않습니다."),
     DUPLICATED_ACCOMPANY_APPLY("이미 신청한 동행 구인글입니다."),
-    ACCOMPANY_APPLY_COMMENT_MODIFICATION_NOT_ALLOWED("동행 신청 댓글은 수정이 불가능 합니다."),
+    ACCOMPANY_APPLY_COMMENT_MODIFY_DENIED("동행 신청 댓글은 수정이 불가능 합니다."),
     ACCOMPANY_APPLY_NOT_ALLOWED_FOR_WRITER("작성자는 동행 신청이 불가능 합니다.");
     private final String message;
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -75,11 +75,11 @@ public class AccompanyGlobalExceptionHandler {
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
 
-    @ExceptionHandler(AccompanyApplyCommentModificationNotAllowedException.class)
-    public ResponseEntity<ErrorResponse> catchAccompanyApplyCommentModificationNotAllowedException(
-            AccompanyApplyCommentModificationNotAllowedException e) {
+    @ExceptionHandler(AccompanyApplyCommentModifyDeniedException.class)
+    public ResponseEntity<ErrorResponse> catchAccompanyApplyCommentModifyDeniedException(
+            AccompanyApplyCommentModifyDeniedException e) {
         log.error(e.getMessage(), e);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AccompanyGlobalExceptionHandler.java
@@ -90,4 +90,12 @@ public class AccompanyGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(AlreadyEndedConcertException.class)
+    public ResponseEntity<ErrorResponse> catchAlreadyEndedConcertException(
+            AlreadyEndedConcertException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/exception/AlreadyEndedConcertException.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/exception/AlreadyEndedConcertException.java
@@ -1,0 +1,14 @@
+package com.gogoring.dongoorami.accompany.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlreadyEndedConcertException extends RuntimeException {
+
+    private final String errorCode;
+
+    public AlreadyEndedConcertException(AccompanyErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostCustomRepositoryImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostCustomRepositoryImpl.java
@@ -66,7 +66,7 @@ public class AccompanyPostCustomRepositoryImpl implements AccompanyPostCustomRep
     }
 
     private BooleanExpression concertPlaceEquals(String concertPlace) {
-        return concertPlace != null ? accompanyPost.concertPlace.eq(concertPlace) : null;
+        return concertPlace != null ? accompanyPost.concert.place.eq(concertPlace) : null;
     }
 
     private BooleanExpression purposesEquals(List<String> purposes) {

--- a/src/main/java/com/gogoring/dongoorami/concert/application/ConcertService.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/application/ConcertService.java
@@ -2,6 +2,8 @@ package com.gogoring.dongoorami.concert.application;
 
 import com.gogoring.dongoorami.concert.dto.request.ConcertReviewRequest;
 import com.gogoring.dongoorami.concert.dto.response.ConcertReviewsGetResponse;
+import com.gogoring.dongoorami.concert.dto.response.ConcertInfoResponse;
+import java.util.List;
 
 public interface ConcertService {
 
@@ -15,4 +17,6 @@ public interface ConcertService {
             Long memberId);
 
     void deleteConcertReview(Long concertReviewId, Long memberId);
+
+    List<ConcertInfoResponse> getConcertsByKeyword(String keyword);
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
@@ -3,6 +3,7 @@ package com.gogoring.dongoorami.concert.application;
 import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.concert.domain.ConcertReview;
 import com.gogoring.dongoorami.concert.dto.request.ConcertReviewRequest;
+import com.gogoring.dongoorami.concert.dto.response.ConcertInfoResponse;
 import com.gogoring.dongoorami.concert.dto.response.ConcertReviewGetResponse;
 import com.gogoring.dongoorami.concert.dto.response.ConcertReviewsGetResponse;
 import com.gogoring.dongoorami.concert.exception.ConcertErrorCode;
@@ -14,6 +15,8 @@ import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.exception.MemberErrorCode;
 import com.gogoring.dongoorami.member.exception.MemberNotFoundException;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -84,5 +87,13 @@ public class ConcertServiceImpl implements ConcertService {
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         concertReview.updateIsActivatedFalse(member.getId());
+    }
+
+    @Override
+    public List<ConcertInfoResponse> getConcertsByKeyword(String keyword) {
+        List<Concert> concerts = concertRepository.findAllByNameContaining(
+                keyword).stream().filter(concert -> concert.getEndLocalDate().isAfter(LocalDate.now())).toList();
+
+        return concerts.stream().map(ConcertInfoResponse::of).toList();
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -111,5 +113,10 @@ public class Concert extends BaseEntity {
         this.status = status;
         this.introductionImages = introductionImages;
         this.schedule = schedule;
+    }
+
+    public LocalDate getEndLocalDate(){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return LocalDate.parse(endedAt, formatter);
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
@@ -115,8 +115,12 @@ public class Concert extends BaseEntity {
         this.schedule = schedule;
     }
 
-    public LocalDate getEndLocalDate(){
+    public LocalDate getEndLocalDate() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         return LocalDate.parse(endedAt, formatter);
+    }
+
+    public void addAccompanyPost(AccompanyPost accompanyPost) {
+        accompanyPosts.add(accompanyPost);
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
@@ -1,5 +1,6 @@
 package com.gogoring.dongoorami.concert.domain;
 
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -8,6 +9,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -79,6 +82,9 @@ public class Concert extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String schedule;
+
+    @OneToMany(mappedBy = "concert")
+    private final List<AccompanyPost> accompanyPosts = new ArrayList<>();
 
     @Builder
     public Concert(String kopisId, String name, String startedAt, String endedAt, String place,

--- a/src/main/java/com/gogoring/dongoorami/concert/dto/response/ConcertInfoResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/dto/response/ConcertInfoResponse.java
@@ -1,0 +1,24 @@
+package com.gogoring.dongoorami.concert.dto.response;
+
+import com.gogoring.dongoorami.concert.domain.Concert;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ConcertInfoResponse {
+
+    private final Long id;
+    private final String name;
+    private final String place;
+
+    public static ConcertInfoResponse of(Concert concert) {
+        return ConcertInfoResponse.builder()
+                .id(concert.getId())
+                .name(concert.getName())
+                .place(concert.getPlace())
+                .build();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/concert/presentation/ConcertController.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/presentation/ConcertController.java
@@ -3,8 +3,10 @@ package com.gogoring.dongoorami.concert.presentation;
 import com.gogoring.dongoorami.concert.application.ConcertService;
 import com.gogoring.dongoorami.concert.dto.request.ConcertReviewRequest;
 import com.gogoring.dongoorami.concert.dto.response.ConcertReviewsGetResponse;
+import com.gogoring.dongoorami.concert.dto.response.ConcertInfoResponse;
 import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -58,5 +60,10 @@ public class ConcertController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         concertService.deleteConcertReview(concertReviewId, customUserDetails.getId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/concerts")
+    public ResponseEntity<List<ConcertInfoResponse>> getConcertsByKeyword(@RequestParam String keyword){
+        return ResponseEntity.ok(concertService.getConcertsByKeyword(keyword));
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/repository/ConcertRepository.java
@@ -1,6 +1,7 @@
 package com.gogoring.dongoorami.concert.repository;
 
 import com.gogoring.dongoorami.concert.domain.Concert;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
     Boolean existsByKopisId(String kopisId);
 
     Optional<Concert> findByIdAndIsActivatedIsTrue(Long id);
+
+    List<Concert> findAllByNameContaining(String keyword);
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/AccompanyDataFactory.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/AccompanyDataFactory.java
@@ -4,6 +4,7 @@ import com.gogoring.dongoorami.accompany.domain.AccompanyComment;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
+import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.member.domain.Member;
 import java.io.FileInputStream;
 import java.time.LocalDate;
@@ -51,13 +52,13 @@ public class AccompanyDataFactory {
         return accompanyComments;
     }
 
-    static public List<AccompanyPost> createAccompanyPosts(Member member, int size) {
+    static public List<AccompanyPost> createAccompanyPosts(Member member, int size,
+            Concert concert) {
         List<AccompanyPost> accompanyPosts = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             accompanyPosts.add(AccompanyPost.builder()
                     .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace("KSPO DOME")
+                    .concert(concert)
                     .startDate(LocalDate.of(2024, 3, 22))
                     .endDate(LocalDate.of(2024, 3, 22))
                     .title("서울 같이 갈 울싼 사람 구합니다~~")
@@ -75,13 +76,12 @@ public class AccompanyDataFactory {
     }
 
     static public List<AccompanyPost> createAccompanyPosts(Member member, int size,
-            AccompanyPostFilterRequest accompanyPostFilterRequest) {
+            AccompanyPostFilterRequest accompanyPostFilterRequest, Concert concert) {
         List<AccompanyPost> accompanyPosts = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             accompanyPosts.add(AccompanyPost.builder()
                     .member(member)
-                    .concertName("2024 SG워너비 콘서트 : 우리의 노래")
-                    .concertPlace(accompanyPostFilterRequest.getConcertPlace())
+                    .concert(concert)
                     .startDate(LocalDate.of(2024, 3, 22))
                     .endDate(LocalDate.of(2024, 3, 22))
                     .title("서울 같이 갈 울싼 사람 구합니다~~")

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
@@ -2,12 +2,15 @@ package com.gogoring.dongoorami.accompany.repository;
 
 import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyComment;
 import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyPosts;
+import static com.gogoring.dongoorami.global.util.TestDataUtil.createConcert;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyComment;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyCommentRequest;
+import com.gogoring.dongoorami.concert.domain.Concert;
+import com.gogoring.dongoorami.concert.repository.ConcertRepository;
 import com.gogoring.dongoorami.global.config.QueryDslConfig;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
@@ -37,6 +40,9 @@ class AccompanyCommentRepositoryTest {
 
     @Autowired
     private AccompanyPostRepository accompanyPostRepository;
+
+    @Autowired
+    private ConcertRepository concertRepository;
 
     @BeforeEach
     void setUp() {
@@ -72,8 +78,9 @@ class AccompanyCommentRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.saveAll(Arrays.asList(member1, member2, member3));
+        Concert concert = concertRepository.save(createConcert());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member1, 1)).get(0);
+                createAccompanyPosts(member1, 1, concert)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
         accompanyComments.addAll(createAccompanyComment(member1, 3));
         accompanyComments.add(AccompanyCommentRequest.createAccompanyApplyCommentRequest()
@@ -106,8 +113,9 @@ class AccompanyCommentRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.saveAll(Arrays.asList(member1, member2));
+        Concert concert = concertRepository.save(createConcert());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member1, 1)).get(0);
+                createAccompanyPosts(member1, 1, concert)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
         accompanyComments.addAll(createAccompanyComment(member1, 3));
         accompanyComments.add(AccompanyCommentRequest.createAccompanyApplyCommentRequest()
@@ -139,8 +147,9 @@ class AccompanyCommentRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.saveAll(Arrays.asList(member1, member2));
+        Concert concert = concertRepository.save(createConcert());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
-                createAccompanyPosts(member1, 1)).get(0);
+                createAccompanyPosts(member1, 1, concert)).get(0);
         List<AccompanyComment> accompanyComments = new ArrayList<>();
         accompanyComments.addAll(createAccompanyComment(member2, 3));
         accompanyComments.add(

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.gogoring.dongoorami.accompany.repository;
 
 import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyPosts;
+import static com.gogoring.dongoorami.global.util.TestDataUtil.createConcert;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
@@ -9,6 +10,8 @@ import static org.hamcrest.Matchers.lessThan;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost.AccompanyPurposeType;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
+import com.gogoring.dongoorami.concert.domain.Concert;
+import com.gogoring.dongoorami.concert.repository.ConcertRepository;
 import com.gogoring.dongoorami.global.config.QueryDslConfig;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
@@ -37,6 +40,9 @@ class AccompanyPostRepositoryTest {
     @Autowired
     private AccompanyPostRepository accompanyPostRepository;
 
+    @Autowired
+    private ConcertRepository concertRepository;
+
     @BeforeEach
     void setUp() {
         accompanyPostRepository.deleteAll();
@@ -59,7 +65,9 @@ class AccompanyPostRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.save(member);
-        accompanyPostRepository.saveAll(createAccompanyPosts(member, 30));
+        Concert concert = concertRepository.save(createConcert());
+        accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, 30, concert));
         int size = 10;
 
         // when
@@ -80,8 +88,10 @@ class AccompanyPostRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.save(member);
-        accompanyPostRepository.saveAll(createAccompanyPosts(member, 30));
-        Long cursorId = 1000000L;
+        Concert concert = concertRepository.save(createConcert());
+        accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, 30, concert));
+        Long cursorId = 1000000000L;
         int size = 10;
 
         // when
@@ -105,13 +115,14 @@ class AccompanyPostRepositoryTest {
                 .providerId("alsjkghlaskdjgh")
                 .build();
         memberRepository.save(member);
+        Concert concert = concertRepository.save(createConcert());
         AccompanyPostFilterRequest accompanyPostFilterRequest1 = AccompanyPostFilterRequest.builder()
                 .gender("남")
                 .region("수도권(경기, 인천 포함)")
                 .startAge(13L)
                 .endAge(17L)
                 .totalPeople(1L)
-                .concertPlace("KSPO DOME")
+                .concertPlace(concert.getPlace())
                 .purposes(Arrays.asList("관람", "숙박", "이동"))
                 .build();
         AccompanyPostFilterRequest accompanyPostFilterRequest2 = AccompanyPostFilterRequest.builder()
@@ -120,14 +131,14 @@ class AccompanyPostRepositoryTest {
                 .startAge(13L)
                 .endAge(17L)
                 .totalPeople(1L)
-                .concertPlace("KSPO DOME")
+                .concertPlace(concert.getPlace())
                 .purposes(Arrays.asList("관람", "숙박"))
                 .build();
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 30, accompanyPostFilterRequest1));
+                createAccompanyPosts(member, 30, accompanyPostFilterRequest1, concert));
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 30, accompanyPostFilterRequest2));
-        Long cursorId = 1000000L;
+                createAccompanyPosts(member, 30, accompanyPostFilterRequest2, concert));
+        Long cursorId = 1000000000L;
         int size = 10;
 
         // when
@@ -174,11 +185,12 @@ class AccompanyPostRepositoryTest {
         AccompanyPostFilterRequest accompanyPostFilterRequest3 = AccompanyPostFilterRequest.builder()
                 .purposes(List.of("관람"))
                 .build();
+        Concert concert = concertRepository.save(createConcert());
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 3, accompanyPostFilterRequest1));
+                createAccompanyPosts(member, 3, accompanyPostFilterRequest1, concert));
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 3, accompanyPostFilterRequest2));
-        Long cursorId = 1000000L;
+                createAccompanyPosts(member, 3, accompanyPostFilterRequest2, concert));
+        Long cursorId = 1000000000L;
         int size = 10;
 
         // when
@@ -227,11 +239,12 @@ class AccompanyPostRepositoryTest {
                 .endAge(13L)
                 .purposes(List.of("관람"))
                 .build();
+        Concert concert = concertRepository.save(createConcert());
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 3, accompanyPostFilterRequest1));
+                createAccompanyPosts(member, 3, accompanyPostFilterRequest1, concert));
         accompanyPostRepository.saveAll(
-                createAccompanyPosts(member, 3, accompanyPostFilterRequest2));
-        Long cursorId = 1000000L;
+                createAccompanyPosts(member, 3, accompanyPostFilterRequest2, concert));
+        Long cursorId = 1000000000L;
         int size = 10;
 
         // when
@@ -263,7 +276,7 @@ class AccompanyPostRepositoryTest {
                                         || accompanyPost.getTotalPeople()
                                         .equals(accompanyPostFilterRequest.getTotalPeople())) &&
                                 (accompanyPostFilterRequest.getConcertPlace() == null
-                                        || accompanyPost.getConcertPlace()
+                                        || accompanyPost.getConcert().getPlace()
                                         .equals(accompanyPostFilterRequest.getConcertPlace())) &&
                                 (accompanyPostFilterRequest.getPurposes() == null
                                         || accompanyPostFilterRequest.getPurposes().isEmpty() ||

--- a/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
@@ -333,7 +333,7 @@ public class ConcertControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 delete("/api/v1/concerts/reviews/{concertReviewId}", concertReview.getId()).header(
-                                "Authorization", accessToken)
+                        "Authorization", accessToken)
         );
 
         // then
@@ -343,6 +343,48 @@ public class ConcertControllerTest {
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("concertReviewId").description("삭제할 공연 후기 아이디")
+                        ))
+                );
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("키워드로 공연 목록을 조회할 수 있다.")
+    void success_getConcertsByKeyword() throws Exception {
+        // given
+        Member member = TestDataUtil.createLoginMemberWithNickname();
+        memberRepository.save(member);
+        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
+                member.getRoles());
+
+        for (int i = 0; i < 7; i++) {
+            concertRepository.save(TestDataUtil.createConcert());
+        }
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/concerts").header(
+                                "Authorization", accessToken)
+                        .param("keyword", "고고링")
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("{ClassName}/getConcertsByKeyword",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("keyword").description("공연 검색 키워드")
+                        ),
+                        responseFields(
+                                fieldWithPath("[]").type(ARRAY)
+                                        .description("공연 정보 목록"),
+                                fieldWithPath("[].id").type(NUMBER)
+                                        .description("공연 아이디"),
+                                fieldWithPath("[].name").type(STRING)
+                                        .description("공연 이름"),
+                                fieldWithPath("[].place").type(STRING)
+                                        .description("공연 장소")
                         ))
                 );
     }

--- a/src/test/java/com/gogoring/dongoorami/concert/repository/ConcertRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/repository/ConcertRepositoryTest.java
@@ -7,6 +7,7 @@ import com.gogoring.dongoorami.concert.exception.ConcertErrorCode;
 import com.gogoring.dongoorami.concert.exception.ConcertNotFoundException;
 import com.gogoring.dongoorami.global.config.QueryDslConfig;
 import com.gogoring.dongoorami.global.util.TestDataUtil;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -64,4 +65,21 @@ public class ConcertRepositoryTest {
         // then
         assertThat(isExist).isEqualTo(true);
     }
+
+    @Test
+    @DisplayName("키워드로 공연 목록을 조회할 수 있다.")
+    void success_findAllByNameContaining() {
+        // given
+        for (int i = 0; i < 7; i++) {
+            concertRepository.save(TestDataUtil.createConcert());
+        }
+
+        // when
+        List<Concert> concerts = concertRepository.findAllByNameContaining("고고링");
+
+        // then
+        assertThat(concerts.size()).isEqualTo(7);
+    }
+
+
 }

--- a/src/test/java/com/gogoring/dongoorami/global/util/TestDataUtil.java
+++ b/src/test/java/com/gogoring/dongoorami/global/util/TestDataUtil.java
@@ -6,6 +6,7 @@ import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import com.gogoring.dongoorami.member.domain.Member;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -38,8 +39,11 @@ public class TestDataUtil {
 
     public static Concert createConcert() {
         return Concert.builder()
-                .kopisId("abcefg")
+                .kopisId(UUID.randomUUID().toString())
                 .name("고고링 백걸즈의 스프링 탐방기")
+                .place("게더")
+                .startedAt("2029.02.01")
+                .endedAt("2029.02.09")
                 .build();
     }
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #55 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
동행 구인글 작성 시, 공연 목록 제공을 위한 키워드 기반 공연 목록 조회 api를 구현하였습니다.
- AccompanyPost의 concertName, concertPlace를 속성을 삭제하고 Concert와 다대일 연관관계 설정
- 동행 구인글 작성 시, 공연 이름과 공연 장소 대신 공연 id를 제공하도록 수정

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
