### PR TITLE
refactor #56: 사용자 인증 불필요한 api 접근 허용 설정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -149,6 +149,7 @@ include::{snippets}/AccompanyControllerTest/getAccompanyPostsAfterFirst/http-res
 include::{snippets}/AccompanyControllerTest/getAccompanyPostsAfterFirst/response-fields.adoc[]
 
 === 동행 구인글 단건 상세 조회
+로그인 한 사용자의 경우, 헤더에 accessToken 값 필요
 
 .Request
 include::{snippets}/AccompanyControllerTest/getAccompanyPost/http-request.adoc[]
@@ -162,6 +163,7 @@ include::{snippets}/AccompanyControllerTest/getAccompanyPost/response-fields.ado
 include::{snippets}/AccompanyControllerTest/createAccompanyComment/http-response.adoc[]
 
 === 특정 동행 구인글 전체 댓글 조회
+로그인 한 사용자의 경우, 헤더에 accessToken 값 필요
 
 .Request
 include::{snippets}/AccompanyControllerTest/getAccompanyComments/http-request.adoc[]
@@ -237,6 +239,7 @@ include::{snippets}/ConcertControllerTest/createConcertReview/request-fields.ado
 include::{snippets}/ConcertControllerTest/createConcertReview/http-response.adoc[]
 
 === 공연 후기 목록 조회(최초 요청)
+로그인 한 사용자의 경우, 헤더에 accessToken 값 필요
 
 .Request
 include::{snippets}/ConcertControllerTest/getConcertReviewsFirst/http-request.adoc[]
@@ -248,6 +251,7 @@ include::{snippets}/ConcertControllerTest/getConcertReviewsFirst/http-response.a
 include::{snippets}/ConcertControllerTest/getConcertReviewsFirst/response-fields.adoc[]
 
 === 공연 후기 목록 조회(이후 요청)
+로그인 한 사용자의 경우, 헤더에 accessToken 값 필요
 
 최초 요청 api와는 cursorId 유무의 차이가 있습니다
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -65,7 +65,7 @@ public class AccompanyController {
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
-                accompanyService.getAccompanyPost(customUserDetails.getId(), accompanyPostId));
+                accompanyService.getAccompanyPost(customUserDetails != null ? customUserDetails.getId() : -1, accompanyPostId));
     }
 
     @PostMapping("/posts")
@@ -95,7 +95,7 @@ public class AccompanyController {
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
-                accompanyService.getAccompanyComments(accompanyPostId, customUserDetails.getId()));
+                accompanyService.getAccompanyComments(accompanyPostId, customUserDetails != null ? customUserDetails.getId() : -1));
     }
 
     @PostMapping("/posts/{accompanyPostId}")

--- a/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
@@ -55,15 +55,13 @@ public class ConcertServiceImpl implements ConcertService {
             Long memberId) {
         Concert concert = concertRepository.findByIdAndIsActivatedIsTrue(concertId).orElseThrow(
                 () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
-        Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Slice<ConcertReviewGetResponse> concertReviewGetResponses = (cursorId == null
                 ? concertReviewRepository.findAllByConcertAndIsActivatedIsTrueOrderByIdDesc(concert,
                 PageRequest.of(0, size))
                 : concertReviewRepository.findAllByIdLessThanAndConcertAndIsActivatedIsTrueOrderByIdDesc(
                         cursorId, concert, PageRequest.of(0, size))).map(
-                concertReview -> ConcertReviewGetResponse.of(concertReview, member));
+                concertReview -> ConcertReviewGetResponse.of(concertReview, memberId));
 
         return ConcertReviewsGetResponse.of(concertReviewGetResponses.hasNext(),
                 concertReviewGetResponses.getContent());

--- a/src/main/java/com/gogoring/dongoorami/concert/dto/response/ConcertReviewGetResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/dto/response/ConcertReviewGetResponse.java
@@ -37,14 +37,14 @@ public class ConcertReviewGetResponse {
         this.updatedAt = updatedAt;
     }
 
-    public static ConcertReviewGetResponse of(ConcertReview concertReview, Member member) {
+    public static ConcertReviewGetResponse of(ConcertReview concertReview, Long memberId) {
         return ConcertReviewGetResponse.builder()
                 .id(concertReview.getId())
-                .nickname(member.getNickname())
+                .nickname(concertReview.getMember().getNickname())
                 .title(concertReview.getTitle())
                 .content(concertReview.getContent())
                 .rating(concertReview.getRating())
-                .isWriter(concertReview.getMember().getId().equals(member.getId()))
+                .isWriter(concertReview.getMember().getId().equals(memberId))
                 .updatedAt(concertReview.getUpdatedAt().toLocalDate())
                 .build();
     }

--- a/src/main/java/com/gogoring/dongoorami/concert/presentation/ConcertController.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/presentation/ConcertController.java
@@ -45,7 +45,7 @@ public class ConcertController {
             @RequestParam(required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(concertService.getConcertReviews(concertId, cursorId, size,
-                customUserDetails.getId()));
+                customUserDetails != null ? customUserDetails.getId() : -1));
     }
 
     @PatchMapping("/concerts/reviews/{concertReviewId}")

--- a/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
+++ b/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -51,6 +52,17 @@ public class SecurityConfig {
                                         "/login/oauth2/code/**", "/oauth/**",
                                         "/actuator/**").permitAll()
                                 .requestMatchers("/api/v1/members/reissue").permitAll()
+                                // 동행 API
+                                .requestMatchers(HttpMethod.GET, "/api/v1/accompanies/posts")
+                                .permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/accompanies/posts/{accompanyPostId}").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/accompanies/comments/{accompanyPostId}").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/accompanies/posts/regions").permitAll()
+                                // 공연 API
+                                .requestMatchers(HttpMethod.GET, "/api/v1/concerts/reviews/{concertId}").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/concerts/{concertId}")
+                                .permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/concerts").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -185,19 +185,17 @@ class AccompanyControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("동행 구인글 목록을 조회할 수 있다. - 최초 요청")
     void success_getAccompanyPostsFirst() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal()).getMember();
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjghjgdslk")
+                .build();
         ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         memberRepository.save(member);
         Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
         String size = "3";
         AccompanyPostFilterRequest accompanyPostFilterRequest1 = AccompanyPostFilterRequest.builder()
                 .gender("여")
@@ -214,7 +212,6 @@ class AccompanyControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/accompanies/posts")
-                        .header("Authorization", accessToken)
                         .param("size", size)
                         .param("gender", accompanyPostFilterRequest1.getGender())
                         .param("region", accompanyPostFilterRequest1.getRegion())
@@ -283,14 +280,14 @@ class AccompanyControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("동행 구인글 목록을 조회할 수 있다. - 이후 요청")
     void success_getAccompanyPostsAfterFirst() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal()).getMember();
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjghjgdslk")
+                .build();
         ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         memberRepository.save(member);
         Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
@@ -383,21 +380,19 @@ class AccompanyControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("동행 구인글을 단건 상세 조회할 수 있다.")
     void success_getAccompanyPost() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal()).getMember();
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjghjgdslk")
+                .build();
         ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "여자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
         Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
                 createAccompanyPosts(member, 1, concert)).get(0);
@@ -406,7 +401,6 @@ class AccompanyControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/accompanies/posts/{accompanyPostId}", accompanyPost.getId())
-                        .header("Authorization", accessToken)
         );
 
         // then
@@ -502,21 +496,19 @@ class AccompanyControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("특정 동행 구인글의 전체 댓글을 조회할 수 있다.")
     void success_getAccompanyComments() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal()).getMember();
+        Member member = Member.builder()
+                .profileImage("image.png")
+                .provider("kakao")
+                .providerId("alsjkghlaskdjghjgdslk")
+                .build();
         ReflectionTestUtils.setField(member, "nickname", "김뫄뫄");
         ReflectionTestUtils.setField(member, "gender", "여자");
         ReflectionTestUtils.setField(member, "birthDate", LocalDate.of(2001, 1, 17));
         ReflectionTestUtils.setField(member, "introduction", "안녕하세요~");
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
         Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
         AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
                 createAccompanyPosts(member, 1, concert)).get(0);
@@ -526,7 +518,6 @@ class AccompanyControllerTest {
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/accompanies/comments/{accompanyPostId}", accompanyPost.getId())
-                        .header("Authorization", accessToken)
         );
 
         // then
@@ -690,22 +681,13 @@ class AccompanyControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("지역 목록을 조회할 수 있다.")
     void success_getAccompanyPostRegions() throws Exception {
         // given
-        Member member = ((CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal()).getMember();
-        memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/accompanies/posts/regions")
-                        .header("Authorization", accessToken)
         );
 
         // then

--- a/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/concert/presentation/ConcertControllerTest.java
@@ -32,6 +32,7 @@ import com.gogoring.dongoorami.global.jwt.TokenProvider;
 import com.gogoring.dongoorami.member.MemberDataFactory;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,14 +131,12 @@ public class ConcertControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("공연 후기 목록을 조회할 수 있다. - 최초 요청")
     void success_getConcertReviewsFirst() throws Exception {
         // given
-        Member member = MemberDataFactory.createLoginMemberWithNickname();
+        Member member = MemberDataFactory.createMember();
+        ReflectionTestUtils.setField(member, "nickname", "백둥이");
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         Concert concert = ConcertDataFactory.createConcert();
         concertRepository.save(concert);
@@ -150,8 +149,7 @@ public class ConcertControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/concerts/reviews/{concertId}", concert.getId()).header(
-                                "Authorization", accessToken)
+                get("/api/v1/concerts/reviews/{concertId}", concert.getId())
                         .param("size", String.valueOf(size))
         );
 
@@ -197,14 +195,12 @@ public class ConcertControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("공연 후기 목록을 조회할 수 있다. - 이후 요청")
     void getConcertReviewsAfterFirst() throws Exception {
         // given
-        Member member = MemberDataFactory.createLoginMemberWithNickname();
+        Member member = MemberDataFactory.createMember();
+        ReflectionTestUtils.setField(member, "nickname", "백둥이");
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         Concert concert = ConcertDataFactory.createConcert();
         concertRepository.save(concert);
@@ -221,8 +217,7 @@ public class ConcertControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/concerts/reviews/{concertId}", concert.getId()).header(
-                                "Authorization", accessToken)
+                get("/api/v1/concerts/reviews/{concertId}", concert.getId())
                         .param("cursorId", String.valueOf(maxId + 1))
                         .param("size", String.valueOf(size))
         );
@@ -353,22 +348,18 @@ public class ConcertControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("공연 단건 상세 조회를 할 수 있다.")
     void success_getConcert() throws Exception {
         // given
-        Member member = MemberDataFactory.createLoginMemberWithNickname();
+        Member member = MemberDataFactory.createMember();
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         Concert concert = ConcertDataFactory.createConcert();
         concertRepository.save(concert);
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/concerts/{concertId}", concert.getId()).header(
-                        "Authorization", accessToken)
+                get("/api/v1/concerts/{concertId}", concert.getId())
         );
 
         // then
@@ -429,14 +420,11 @@ public class ConcertControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("공연 목록을 조회할 수 있다. - 최초 요청")
     void success_getConcertsFirst() throws Exception {
         // given
-        Member member = MemberDataFactory.createLoginMemberWithNickname();
+        Member member = MemberDataFactory.createMember();
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         int size = 3;
         List<Concert> concerts = ConcertDataFactory.createConcerts(size);
@@ -444,8 +432,7 @@ public class ConcertControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/concerts").header(
-                                "Authorization", accessToken)
+                get("/api/v1/concerts")
                         .param("size", String.valueOf(size))
                         .param("keyword", concerts.get(0).getName()
                                 .substring(0, concerts.get(0).getName().length() / 2))
@@ -496,14 +483,11 @@ public class ConcertControllerTest {
     }
 
     @Test
-    @WithCustomMockUser
     @DisplayName("공연 목록을 조회할 수 있다. - 이후 요청")
     void success_getConcertsAfterFirst() throws Exception {
         // given
-        Member member = MemberDataFactory.createLoginMemberWithNickname();
+        Member member = MemberDataFactory.createMember();
         memberRepository.save(member);
-        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
-                member.getRoles());
 
         int size = 3;
         List<Concert> concerts = ConcertDataFactory.createConcerts(size);
@@ -515,8 +499,7 @@ public class ConcertControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/concerts").header(
-                                "Authorization", accessToken)
+                get("/api/v1/concerts")
                         .param("cursorId", String.valueOf(maxId))
                         .param("size", String.valueOf(size))
                         .param("keyword", concerts.get(0).getName()


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #56

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
슬랙에 남겨둔대로 아래 API들에 대해 사용자 인증 없이도 접근 가능하도록 설정했습니다!
동행 API
- 동행 구인글 필터링 목록 조회(무한 스크롤)
- 동행 구인글 단건 상세 조회
- 특정 동행 구인글 전체 댓글 조회
- 동행 구인글 지역 목록 조회

공연 API
- 공연 후기 목록 조회(최초 요청)
- 공연 후기 목록 조회(이후 요청)
- 공연 단건 조회
- 공연 목록 조회(최초 요청)
- 공연 목록 조회(이후 요청)

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
아래 API들의 경우, 본인 여부 판단을 위해 CustomUserDetails 받고 있어,
해당 값이 null인 경우 CustomUserDetails에서 멤버 id를 받아오는 대신 -1 값을 서비스 단으로 넘겨주도록 하였습니다.
- 동행 구인글 단건 상세 조회
- 특정 동행 구인글 전체 댓글 조회
- 공연 후기 목록 조회

이 과정에서 ConcertService 로직이 조금 수정되었는데 확인 부탁드립니다! [65b314e](https://github.com/GoGo-Ring/dongoorami-backend/commit/65b314e40309c7e96a474c7303db7f5262e3c597)