### PR TITLE
feat #66: 동행 후기 상태 및 동행 구인글 상태 변경 로직 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -97,7 +97,7 @@ include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/req
 include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/request-part-accompanyPostRequest-fields.adoc[]
 
 .Response
-include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/http-response.adoc[]
 
 === 동행 구인글 수정
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -234,7 +234,7 @@ include::{snippets}/AccompanyControllerTest/confirmAccompany/path-parameters.ado
 .Response
 include::{snippets}/AccompanyControllerTest/confirmAccompany/http-response.adoc[]
 
-== 동행 구인글 상태 모집 완료로 변경
+=== 동행 구인글 상태 모집 완료로 변경
 include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/http-request.adoc[]
 include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/path-parameters.adoc[]
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -227,6 +227,13 @@ include::{snippets}/AccompanyControllerTest/confirmAccompany/path-parameters.ado
 .Response
 include::{snippets}/AccompanyControllerTest/confirmAccompany/http-response.adoc[]
 
+== 동행 구인글 상태 완료로 변경
+include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/http-response.adoc[]
+
 === 특정 동행 구인글에 대한 리뷰 대상자 조회
 
 .Request

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -92,9 +92,9 @@ include::{snippets}/AccompanyControllerTest/createAccompanyPost/request-part-acc
 === 동행 구인글 작성(이미지 없는 경우)
 
 .Request
-include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/http-request.adoc[]
-include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/request-parts.adoc[]
-include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/request-part-accompanyPostRequest-fields.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/request-parts.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostGivenNoImages/request-part-accompanyPostRequest-fields.adoc[]
 
 .Response
 include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -89,8 +89,15 @@ include::{snippets}/AccompanyControllerTest/createAccompanyPost/http-request.ado
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/request-parts.adoc[]
 include::{snippets}/AccompanyControllerTest/createAccompanyPost/request-part-accompanyPostRequest-fields.adoc[]
 
+=== 동행 구인글 작성(이미지 없는 경우)
+
+.Request
+include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/request-parts.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/request-part-accompanyPostRequest-fields.adoc[]
+
 .Response
-include::{snippets}/AccompanyControllerTest/createAccompanyPost/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/createAccompanyPostWithNoImages/http-response.adoc[]
 
 === 동행 구인글 수정
 
@@ -227,7 +234,7 @@ include::{snippets}/AccompanyControllerTest/confirmAccompany/path-parameters.ado
 .Response
 include::{snippets}/AccompanyControllerTest/confirmAccompany/http-response.adoc[]
 
-== 동행 구인글 상태 완료로 변경
+== 동행 구인글 상태 모집 완료로 변경
 include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/http-request.adoc[]
 include::{snippets}/AccompanyControllerTest/updateAccompanyPostStatusCompleted/path-parameters.adoc[]
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -48,4 +48,6 @@ public interface AccompanyService {
 
     void updateAccompanyReview(List<AccompanyReviewRequest> accompanyReviewRequests,
             Long accompanyPostId, Long currentMemberId);
+
+    void updateAccompanyPostStatusCompleted(Long accompanyPostId, Long currentMemberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -2,6 +2,7 @@ package com.gogoring.dongoorami.accompany.application;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyComment;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost.RecruitmentStatusType;
 import com.gogoring.dongoorami.accompany.domain.AccompanyReview;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyCommentRequest;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
@@ -223,8 +224,11 @@ public class AccompanyServiceImpl implements AccompanyService {
         checkConfirmerIsWriter(currentMemberId, accompanyPost.getWriter().getId());
         checkAccompanyCommentIsApplyComment(accompanyComment);
         checkAlreadyConfirmedAccompanyApplyComment(accompanyComment);
-        createAccompanyReview(accompanyPost,
-                getAccompanyConfirmedMembers(accompanyPost, accompanyComment.getMember()));
+        List<Member> accompanyConfirmedMembers = getAccompanyConfirmedMembers(accompanyPost, accompanyComment.getMember());
+        if(accompanyPost.getTotalPeople()==accompanyConfirmedMembers.size()){
+            accompanyPost.updateStatus(RecruitmentStatusType.COMPLETED);
+        }
+        createAccompanyReview(accompanyPost, accompanyConfirmedMembers);
         accompanyComment.updateIsAccompanyConfirmedComment();
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -125,7 +125,7 @@ public class AccompanyServiceImpl implements AccompanyService {
                         accompanyPostId)
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
                         AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
-        List<AccompanyCommentInfo> accompanyCommentInfos = accompanyCommentRepository.findAllByAccompanyPostId(
+        List<AccompanyCommentInfo> accompanyCommentInfos = accompanyCommentRepository.findAllByAccompanyPostIdAndIsActivatedIsTrue(
                         accompanyPostId)
                 .stream()
                 .filter(AccompanyComment::isActivated)
@@ -164,7 +164,7 @@ public class AccompanyServiceImpl implements AccompanyService {
                         accompanyPostId)
                 .orElseThrow(() -> new AccompanyPostNotFoundException(
                         AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
-        accompanyCommentRepository.findAllByAccompanyPostId(accompanyPostId).forEach(
+        accompanyCommentRepository.findAllByAccompanyPostIdAndIsActivatedIsTrue(accompanyPostId).forEach(
                 accompanyComment -> accompanyComment.updateIsActivatedFalse(currentMemberId));
         accompanyPost.updateIsActivatedFalse();
     }
@@ -325,7 +325,7 @@ public class AccompanyServiceImpl implements AccompanyService {
     }
 
     private void checkDuplicatedAccompanyApply(Long accompanyPostId, Long memberId) {
-        if (accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
+        if (accompanyCommentRepository.existsByAccompanyPostIdAndIsActivatedIsTrueAndMemberIdAndIsAccompanyApplyCommentTrue(
                 accompanyPostId, memberId)) {
             throw new DuplicatedAccompanyApplyException(
                     AccompanyErrorCode.DUPLICATED_ACCOMPANY_APPLY);

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -2,7 +2,6 @@ package com.gogoring.dongoorami.accompany.application;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyComment;
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
-import com.gogoring.dongoorami.accompany.domain.AccompanyPost.RecruitmentStatusType;
 import com.gogoring.dongoorami.accompany.domain.AccompanyReview;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyCommentRequest;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
@@ -224,9 +223,10 @@ public class AccompanyServiceImpl implements AccompanyService {
         checkConfirmerIsWriter(currentMemberId, accompanyPost.getWriter().getId());
         checkAccompanyCommentIsApplyComment(accompanyComment);
         checkAlreadyConfirmedAccompanyApplyComment(accompanyComment);
-        List<Member> accompanyConfirmedMembers = getAccompanyConfirmedMembers(accompanyPost, accompanyComment.getMember());
-        if(accompanyPost.getTotalPeople()==accompanyConfirmedMembers.size()){
-            accompanyPost.updateStatus(RecruitmentStatusType.COMPLETED);
+        List<Member> accompanyConfirmedMembers = getAccompanyConfirmedMembers(accompanyPost,
+                accompanyComment.getMember());
+        if (accompanyPost.getTotalPeople() == accompanyConfirmedMembers.size()) {
+            accompanyPost.updateStatus();
         }
         createAccompanyReview(accompanyPost, accompanyConfirmedMembers);
         accompanyComment.updateIsAccompanyConfirmedComment();
@@ -258,6 +258,18 @@ public class AccompanyServiceImpl implements AccompanyService {
                             accompanyReviewRepository.averageRatingPercentByRevieweeId(member.getId()));
                 }
         );
+    }
+
+    @Transactional
+    @Override
+    public void updateAccompanyPostStatusCompleted(Long accompanyPostId, Long currentMemberId) {
+        AccompanyPost accompanyPost = accompanyPostRepository.findByIdAndIsActivatedIsTrue(
+                        accompanyPostId)
+                .orElseThrow(() -> new AccompanyPostNotFoundException(
+                        AccompanyErrorCode.ACCOMPANY_POST_NOT_FOUND));
+        Member member = memberRepository.findByIdAndIsActivatedIsTrue(currentMemberId)
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+        accompanyPost.updateStatus(member.getId());
     }
 
     private List<Member> getAccompanyConfirmedMembers(AccompanyPost accompanyPost,

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -97,14 +97,18 @@ public class AccompanyPost extends BaseEntity {
         this.purposes = accompanyPost.purposes;
     }
 
-    public void updateStatus(RecruitmentStatusType status) {
-        this.status = status;
+    public void updateStatus() {
+        this.status = RecruitmentStatusType.COMPLETED;
+    }
+
+    public void updateStatus(Long memberId) {
+        checkIsWriter(memberId);
+        this.status = RecruitmentStatusType.COMPLETED;
     }
 
     private void checkIsWriter(Long memberId) {
         if (!this.writer.getId().equals(memberId)) {
             throw new OnlyWriterCanModifyException(AccompanyErrorCode.ONLY_WRITER_CAN_MODIFY);
-
         }
     }
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyPost.java
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 public class AccompanyPost extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
-    private final RecruitmentStatusType status = RecruitmentStatusType.PROCEEDING;
+    private RecruitmentStatusType status = RecruitmentStatusType.PROCEEDING;
     private Long viewCount = 0L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -95,6 +95,10 @@ public class AccompanyPost extends BaseEntity {
         this.content = accompanyPost.content;
         this.images = accompanyPost.images;
         this.purposes = accompanyPost.purposes;
+    }
+
+    public void updateStatus(RecruitmentStatusType status) {
+        this.status = status;
     }
 
     private void checkIsWriter(Long memberId) {

--- a/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyReview.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/domain/AccompanyReview.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class AccompanyReview extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
-    private final AccompanyReviewStatusType status = AccompanyReviewStatusType.BEFORE_ACCOMPANY;
+    private AccompanyReviewStatusType status = AccompanyReviewStatusType.BEFORE_ACCOMPANY;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -62,6 +62,10 @@ public class AccompanyReview extends BaseEntity {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void updateStatus(AccompanyReviewStatusType status) {
+        this.status = status;
     }
 
     public enum AccompanyReviewStatusType {

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -66,7 +66,9 @@ public class AccompanyController {
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
-                accompanyService.getAccompanyPost(customUserDetails != null ? customUserDetails.getId() : -1, accompanyPostId));
+                accompanyService.getAccompanyPost(
+                        customUserDetails != null ? customUserDetails.getId() : -1,
+                        accompanyPostId));
     }
 
     @PostMapping("/posts")
@@ -96,7 +98,8 @@ public class AccompanyController {
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
-                accompanyService.getAccompanyComments(accompanyPostId, customUserDetails != null ? customUserDetails.getId() : -1));
+                accompanyService.getAccompanyComments(accompanyPostId,
+                        customUserDetails != null ? customUserDetails.getId() : -1));
     }
 
     @PostMapping("/posts/{accompanyPostId}")
@@ -184,6 +187,15 @@ public class AccompanyController {
             @PathVariable Long accompanyPostId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         accompanyService.updateAccompanyReview(accompanyReviewRequests, accompanyPostId,
+                customUserDetails.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/posts/{accompanyPostId}/status")
+    public ResponseEntity<Void> updateAccompanyPostStatus(
+            @PathVariable Long accompanyPostId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        accompanyService.updateAccompanyPostStatusCompleted(accompanyPostId,
                 customUserDetails.getId());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepository.java
@@ -9,13 +9,13 @@ public interface AccompanyCommentRepository extends JpaRepository<AccompanyComme
 
     Optional<AccompanyComment> findByIdAndIsActivatedIsTrue(Long id);
 
-    List<AccompanyComment> findAllByAccompanyPostId(Long accompanyPostId);
+    List<AccompanyComment> findAllByAccompanyPostIdAndIsActivatedIsTrue(Long accompanyPostId);
 
     long countByAccompanyPostIdAndIsActivatedIsTrue(Long accompanyPostId);
 
     Long countByAccompanyPostIdAndIsActivatedIsTrueAndIsAccompanyApplyCommentTrue(
             Long accompanyPostId);
 
-    boolean existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(Long accompanyPostId,
+    boolean existsByAccompanyPostIdAndIsActivatedIsTrueAndMemberIdAndIsAccompanyApplyCommentTrue(Long accompanyPostId,
             Long memberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepository.java
@@ -27,4 +27,9 @@ public interface AccompanyReviewRepository extends JpaRepository<AccompanyReview
 
     @Query("SELECT AVG(ar.rating)*20 FROM AccompanyReview ar WHERE ar.reviewee.id = :revieweeId")
     Integer averageRatingPercentByRevieweeId(@Param("revieweeId") Long revieweeId);
+
+    @Query("SELECT ar FROM AccompanyReview ar " +
+            "JOIN ar.accompanyPost ap " +
+            "WHERE ap.concert.id = :concertId")
+    List<AccompanyReview> findAllByConcertId(Long concertId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepository.java
@@ -30,6 +30,11 @@ public interface AccompanyReviewRepository extends JpaRepository<AccompanyReview
 
     @Query("SELECT ar FROM AccompanyReview ar " +
             "JOIN ar.accompanyPost ap " +
-            "WHERE ap.concert.id = :concertId")
-    List<AccompanyReview> findAllByConcertId(Long concertId);
+            "JOIN ap.concert c " +
+            "WHERE c.id = :concertId " +
+            "AND c.isActivated = true " +
+            "AND ar.status = 'BEFORE_ACCOMPANY' " +
+            "AND ar.isActivated = true")
+    List<AccompanyReview> findAllByConcertIdAndActivatedConcertAndActivatedAccompanyReviewAndProceedingStatus(Long concertId);
+
 }

--- a/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/application/ConcertServiceImpl.java
@@ -136,7 +136,7 @@ public class ConcertServiceImpl implements ConcertService {
                     concert.updateStatus();
                     if (concert.isOneDayPassedSinceEndedAt()) {
                         updateAccompanyReviewsStatus(
-                                accompanyReviewRepository.findAllByConcertId(concert.getId()));
+                                accompanyReviewRepository.findAllByConcertIdAndActivatedConcertAndActivatedAccompanyReviewAndProceedingStatus(concert.getId()));
                     }
                 });
     }

--- a/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
+++ b/src/main/java/com/gogoring/dongoorami/concert/domain/Concert.java
@@ -127,4 +127,7 @@ public class Concert extends BaseEntity {
         return LocalDate.parse(endedAt, formatter);
     }
 
+    public boolean isOneDayPassedSinceEndedAt() {
+        return LocalDate.now().isAfter(getEndLocalDate().plusDays(1));
+    }
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -1030,7 +1030,7 @@ class AccompanyControllerTest {
     @Test
     @WithCustomMockUser
     @DisplayName("특정 동행 구인글에 대해 모든 리뷰를 작성할 수 있다.")
-    void updateAccompanyReviews() throws Exception {
+    void success_updateAccompanyReviews() throws Exception {
         // given
         Member member1 = ((CustomUserDetails) SecurityContextHolder
                 .getContext()
@@ -1094,5 +1094,38 @@ class AccompanyControllerTest {
                                         .description("평가 항목")
                         ))
                 );
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("특정 동행 구인글의 동행 상태를 변경할 수 있다.")
+    void success_updateAccompanyPostStatusCompleted() throws Exception {
+        // given
+        Member member = ((CustomUserDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal()).getMember();
+        memberRepository.save(member);
+        String accessToken = tokenProvider.createAccessToken(member.getProviderId(),
+                member.getRoles());
+        Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
+        AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, 1, concert)).get(0);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/accompanies/posts/{accompanyPostId}/status", accompanyPost.getId())
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("{ClassName}/updateAccompanyPostStatusCompleted",
+                        preprocessRequest(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("accompanyPostId").description("동행 구인글 id")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyCommentRepositoryTest.java
@@ -148,7 +148,7 @@ class AccompanyCommentRepositoryTest {
         accompanyCommentRepository.saveAll(accompanyComments);
 
         // when
-        boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
+        boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndIsActivatedIsTrueAndMemberIdAndIsAccompanyApplyCommentTrue(
                 accompanyPost.getId(),
                 member2.getId());
 
@@ -182,7 +182,7 @@ class AccompanyCommentRepositoryTest {
         accompanyCommentRepository.saveAll(accompanyComments);
 
         // when
-        boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndMemberIdAndIsAccompanyApplyCommentTrue(
+        boolean isAccompanyApplied = accompanyCommentRepository.existsByAccompanyPostIdAndIsActivatedIsTrueAndMemberIdAndIsAccompanyApplyCommentTrue(
                 accompanyPost.getId(),
                 member2.getId());
 

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepositoryTest.java
@@ -296,7 +296,7 @@ class AccompanyReviewRepositoryTest {
                 createAccompanyReview(accompanyPost, members)).size();
 
         // when
-        List<AccompanyReview> accompanyReviews = accompanyReviewRepository.findAllByConcertId(
+        List<AccompanyReview> accompanyReviews = accompanyReviewRepository.findAllByConcertIdAndActivatedConcertAndActivatedAccompanyReviewAndProceedingStatus(
                 concert.getId());
 
         // then

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyReviewRepositoryTest.java
@@ -2,6 +2,7 @@ package com.gogoring.dongoorami.accompany.repository;
 
 import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyComment;
 import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyPosts;
+import static com.gogoring.dongoorami.accompany.AccompanyDataFactory.createAccompanyReview;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -14,6 +15,7 @@ import com.gogoring.dongoorami.concert.ConcertDataFactory;
 import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.concert.repository.ConcertRepository;
 import com.gogoring.dongoorami.global.config.QueryDslConfig;
+import com.gogoring.dongoorami.member.MemberDataFactory;
 import com.gogoring.dongoorami.member.domain.Member;
 import com.gogoring.dongoorami.member.repository.MemberRepository;
 import java.util.ArrayList;
@@ -276,5 +278,28 @@ class AccompanyReviewRepositoryTest {
 
         // then
         assertThat(ratingAveragePercent, equalTo((5 + 4 + 3) / 3 * 20));
+    }
+
+    @Test
+    @DisplayName("특정 공연에 대한 동행 목록을 조회할 수 있다.")
+    void success_findAllByConcertId() {
+        // given
+        Member member1 = MemberDataFactory.createMember();
+        Member member2 = MemberDataFactory.createMember();
+        Member member3 = MemberDataFactory.createMember();
+        List<Member> members = Arrays.asList(member1, member2, member3);
+        memberRepository.saveAll(members);
+        Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
+        AccompanyPost accompanyPost = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member1, 1, concert)).get(0);
+        int size = accompanyReviewRepository.saveAll(
+                createAccompanyReview(accompanyPost, members)).size();
+
+        // when
+        List<AccompanyReview> accompanyReviews = accompanyReviewRepository.findAllByConcertId(
+                concert.getId());
+
+        // then
+        assertThat(accompanyReviews.size(), equalTo(size));
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #66

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
 공연 종료 24시간 이후, 동행 후기 상태 값을 "작성 필요"로 변경하도록 하였습니다.
- updateConcertStatus의 스케줄러와 함께 돌아갑니다.

동행 구인글 모집 상태의 경우 아래 두가지 경우에 대해 "모집 완료"로 변경하도록 하였습니다.
- 모집 인원수와 동행 신청자가 같아짐.
- 수동으로 모집 완료 api 요청

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
동행 게시글 작성 시, 이미지가 없는 경우에 대하여 api 요청 값 형식 제공이 필요하여 추가하였습니다.