### PR TITLE
feat #71: 특정 회원이 받은 후기 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -321,6 +321,29 @@ include::{snippets}/AccompanyControllerTest/updateAccompanyReviews/request-field
 .Response
 include::{snippets}/AccompanyControllerTest/updateAccompanyReviews/http-response.adoc[]
 
+=== 특정 회원이 받은 후기 조회(최초 요청)
+
+.Request
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdFirst/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdFirst/query-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdFirst/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdFirst/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdFirst/response-fields.adoc[]
+
+=== 특정 회원이 받은 후기 조회(이후 요청)
+최초 요청 api와는 cursorId 유무의 차이가 있습니다
+
+.Request
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/query-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/response-fields.adoc[]
+
 == 공연 API
 === 공연 후기 작성
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -7,8 +7,8 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyReviewRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
-import com.gogoring.dongoorami.accompany.dto.response.ReviewsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
+import com.gogoring.dongoorami.accompany.dto.response.ReviewsResponse;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -52,7 +52,7 @@ public interface AccompanyService {
 
     void updateAccompanyPostStatusCompleted(Long accompanyPostId, Long currentMemberId);
 
-    ReviewsResponse getReceivedReviews(Long cursorId, int size, Long currentMemberId);
+    ReviewsResponse getReceivedReviews(Long cursorId, int size, Long memberId);
 
     ReviewsResponse getWaitingReviews(Long cursorId, int size, Long currentMemberId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -13,9 +13,9 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse.
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
+import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
 import com.gogoring.dongoorami.accompany.dto.response.ReviewResponse;
 import com.gogoring.dongoorami.accompany.dto.response.ReviewsResponse;
-import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
 import com.gogoring.dongoorami.accompany.exception.AccompanyApplyCommentModifyDeniedException;
 import com.gogoring.dongoorami.accompany.exception.AccompanyApplyNotAllowedForWriterException;
 import com.gogoring.dongoorami.accompany.exception.AccompanyCommentApplyConfirmDeniedException;
@@ -280,18 +280,18 @@ public class AccompanyServiceImpl implements AccompanyService {
 
     @Override
     public ReviewsResponse getReceivedReviews(Long cursorId, int size,
-            Long currentMemberId) {
-        Member member = memberRepository.findByIdAndIsActivatedIsTrue(currentMemberId)
+            Long memberId) {
+        Member member = memberRepository.findByIdAndIsActivatedIsTrue(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Slice<AccompanyReview> accompanyReviews = accompanyReviewRepository.findAllByMemberAndStatus(
                 cursorId, size, member, false,
                 AccompanyReviewStatusType.AFTER_ACCOMPANY_AND_WRITTEN);
-        List<ReviewResponse> reviewRespons = accompanyReviews.stream()
+        List<ReviewResponse> reviewResponses = accompanyReviews.stream()
                 .map(ReviewResponse::of)
                 .toList();
 
-        return ReviewsResponse.of(accompanyReviews.hasNext(), reviewRespons);
+        return ReviewsResponse.of(accompanyReviews.hasNext(), reviewResponses);
     }
 
     @Override
@@ -303,11 +303,11 @@ public class AccompanyServiceImpl implements AccompanyService {
         Slice<AccompanyReview> accompanyReviews = accompanyReviewRepository.findAllByMemberAndStatus(
                 cursorId, size, member, true,
                 AccompanyReviewStatusType.AFTER_ACCOMPANY_AND_NOT_WRITTEN);
-        List<ReviewResponse> reviewRespons = accompanyReviews.stream()
+        List<ReviewResponse> reviewResponses = accompanyReviews.stream()
                 .map(ReviewResponse::of)
                 .toList();
 
-        return ReviewsResponse.of(accompanyReviews.hasNext(), reviewRespons);
+        return ReviewsResponse.of(accompanyReviews.hasNext(), reviewResponses);
     }
 
     private List<Member> getAccompanyConfirmedMembers(AccompanyPost accompanyPost,

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -9,8 +9,8 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyReviewRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
-import com.gogoring.dongoorami.accompany.dto.response.ReviewsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
+import com.gogoring.dongoorami.accompany.dto.response.ReviewsResponse;
 import com.gogoring.dongoorami.global.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -217,5 +217,14 @@ public class AccompanyController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
                 accompanyService.getWaitingReviews(cursorId, size, customUserDetails.getId()));
+    }
+
+    @GetMapping("/reviews/reviewees/{memberId}")
+    public ResponseEntity<ReviewsResponse> getReceivedReviews(
+            @PathVariable Long memberId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") int size) {
+        return ResponseEntity.ok(
+                accompanyService.getReceivedReviews(cursorId, size, memberId));
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #71 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
마이페이지에서 사용되는 받은 후기 조회 api와 로직이 동일하여 컨트롤러와 테스트 코드만 추가됐습니다!

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
