### PR TITLE
feat #73: 특정 공연에 대한 동행 구인글 목록 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -386,6 +386,29 @@ include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterF
 include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/http-response.adoc[]
 include::{snippets}/AccompanyControllerTest/getReceivedReviewsWithMemberIdAfterFirst/response-fields.adoc[]
 
+=== 특정 공연에 대한 동행 구인글 목록 조회(최초 요청)
+
+.Request
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertFirst/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertFirst/query-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertFirst/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertFirst/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertFirst/response-fields.adoc[]
+
+=== 특정 공연에 대한 동행 구인글 목록 조회(이후 요청)
+최초 요청 api와는 cursorId 유무의 차이가 있습니다
+
+.Request
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertAfterFirst/http-request.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertAfterFirst/query-parameters.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertAfterFirst/path-parameters.adoc[]
+
+.Response
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertAfterFirst/http-response.adoc[]
+include::{snippets}/AccompanyControllerTest/getAccompanyPostsByConcertAfterFirst/response-fields.adoc[]
+
 == 공연 API
 === 공연 후기 작성
 

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyService.java
@@ -7,6 +7,7 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyReviewRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsShortResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
+import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsConcertResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsShortResponse;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
@@ -63,4 +64,7 @@ public interface AccompanyService {
 
     AccompanyCommentsShortResponse getAccompanyCommentsByMember(Long cursorId, int size,
             Long currentMemberId);
+
+    AccompanyPostsConcertResponse getAccompanyPostsByConcert(Long cursorId, int size,
+            Long concertId);
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/application/AccompanyServiceImpl.java
@@ -12,8 +12,10 @@ import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentShortRespo
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse.AccompanyCommentInfo;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsShortResponse;
+import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostConcertResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostShortResponse;
+import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsConcertResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse.AccompanyPostInfo;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsShortResponse;
@@ -346,6 +348,23 @@ public class AccompanyServiceImpl implements AccompanyService {
                 accompanyCommentShortResponses);
     }
 
+    @Override
+    public AccompanyPostsConcertResponse getAccompanyPostsByConcert(Long cursorId, int size,
+            Long concertId) {
+        Concert concert = concertRepository.findByIdAndIsActivatedIsTrue(concertId).orElseThrow(
+                () -> new ConcertNotFoundException(ConcertErrorCode.CONCERT_NOT_FOUND));
+
+        Slice<AccompanyPost> accompanyPosts = accompanyPostRepository.findAllByConcert(cursorId,
+                size, concert);
+        List<AccompanyPostConcertResponse> accompanyPostConcertResponses = accompanyPosts.stream()
+                .map(accompanyPost -> AccompanyPostConcertResponse.of(accompanyPost,
+                        accompanyCommentRepository.countByAccompanyPostIdAndIsActivatedIsTrue(
+                                accompanyPost.getId()))).toList();
+
+        return AccompanyPostsConcertResponse.of(accompanyPosts.hasNext(),
+                accompanyPostConcertResponses);
+    }
+
     private List<Member> getAccompanyConfirmedMembers(AccompanyPost accompanyPost,
             Member newCompanion) {
         List<Member> companions = new ArrayList<>();
@@ -440,6 +459,4 @@ public class AccompanyServiceImpl implements AccompanyService {
                     AccompanyErrorCode.ALREADY_APPLY_CONFIRMED_ACCOMPANY_COMMENT);
         }
     }
-
-
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostConcertResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostConcertResponse.java
@@ -1,0 +1,50 @@
+package com.gogoring.dongoorami.accompany.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AccompanyPostConcertResponse {
+
+    private final Long id;
+
+    private final String nickname;
+
+    private final String title;
+
+    private final String content;
+
+    private final Long viewCount;
+
+    private final Long commentCount;
+
+    @JsonFormat(pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+    private final LocalDate updatedAt;
+
+    @Builder
+    public AccompanyPostConcertResponse(Long id, String nickname, String title, String content,
+            Long viewCount, Long commentCount, LocalDate updatedAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.title = title;
+        this.content = content;
+        this.viewCount = viewCount;
+        this.commentCount = commentCount;
+        this.updatedAt = updatedAt;
+    }
+
+    public static AccompanyPostConcertResponse of(AccompanyPost accompanyPost, Long commentCount) {
+        return AccompanyPostConcertResponse.builder()
+                .id(accompanyPost.getId())
+                .nickname(accompanyPost.getWriter().getNickname())
+                .title(accompanyPost.getTitle())
+                .content(accompanyPost.getContent())
+                .viewCount(accompanyPost.getViewCount())
+                .commentCount(commentCount)
+                .updatedAt(accompanyPost.getUpdatedAt().toLocalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsConcertResponse.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/dto/response/AccompanyPostsConcertResponse.java
@@ -1,0 +1,28 @@
+package com.gogoring.dongoorami.accompany.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AccompanyPostsConcertResponse {
+
+    private final Boolean hasNext;
+
+    private final List<AccompanyPostConcertResponse> accompanyPostConcertResponses;
+
+    @Builder
+    public AccompanyPostsConcertResponse(Boolean hasNext,
+            List<AccompanyPostConcertResponse> accompanyPostConcertResponses) {
+        this.hasNext = hasNext;
+        this.accompanyPostConcertResponses = accompanyPostConcertResponses;
+    }
+
+    public static AccompanyPostsConcertResponse of(Boolean hasNext,
+            List<AccompanyPostConcertResponse> accompanyPostConcertResponses) {
+        return AccompanyPostsConcertResponse.builder()
+                .hasNext(hasNext)
+                .accompanyPostConcertResponses(accompanyPostConcertResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/presentation/AccompanyController.java
@@ -9,6 +9,7 @@ import com.gogoring.dongoorami.accompany.dto.request.AccompanyReviewRequest;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyCommentsShortResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostResponse;
+import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsConcertResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsResponse;
 import com.gogoring.dongoorami.accompany.dto.response.AccompanyPostsShortResponse;
 import com.gogoring.dongoorami.accompany.dto.response.MemberProfile;
@@ -246,5 +247,14 @@ public class AccompanyController {
             @RequestParam(required = false, defaultValue = "10") int size) {
         return ResponseEntity.ok(
                 accompanyService.getReceivedReviews(cursorId, size, memberId));
+    }
+
+    @GetMapping("/posts/concerts/{concertId}")
+    public ResponseEntity<AccompanyPostsConcertResponse> getAccompanyPostsByConcert(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @PathVariable Long concertId) {
+        return ResponseEntity.ok(
+                accompanyService.getAccompanyPostsByConcert(cursorId, size, concertId));
     }
 }

--- a/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostCustomRepository.java
+++ b/src/main/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostCustomRepository.java
@@ -2,6 +2,7 @@ package com.gogoring.dongoorami.accompany.repository;
 
 import com.gogoring.dongoorami.accompany.domain.AccompanyPost;
 import com.gogoring.dongoorami.accompany.dto.request.AccompanyPostFilterRequest;
+import com.gogoring.dongoorami.concert.domain.Concert;
 import com.gogoring.dongoorami.member.domain.Member;
 import org.springframework.data.domain.Slice;
 
@@ -11,4 +12,6 @@ public interface AccompanyPostCustomRepository {
             AccompanyPostFilterRequest accompanyPostFilterRequest);
 
     Slice<AccompanyPost> findAllByMember(Long cursorId, int size, Member member);
+
+    Slice<AccompanyPost> findAllByConcert(Long cursorId, int size, Concert concert);
 }

--- a/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
+++ b/src/main/java/com/gogoring/dongoorami/global/config/SecurityConfig.java
@@ -63,6 +63,9 @@ public class SecurityConfig {
                                 .permitAll()
                                 .requestMatchers(HttpMethod.GET,
                                         "/api/v1/accompanies/posts/regions").permitAll()
+                                .requestMatchers(HttpMethod.GET,
+                                        "/api/v1/accompanies/posts/concerts/{concertId}")
+                                .permitAll()
                                 // 공연 API
                                 .requestMatchers(HttpMethod.GET,
                                         "/api/v1/concerts/reviews/{concertId}").permitAll()

--- a/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/presentation/AccompanyControllerTest.java
@@ -1621,11 +1621,11 @@ class AccompanyControllerTest {
                                 fieldWithPath("accompanyPostShortResponses[].totalPeople").type(
                                         NUMBER).description("모집 인원"),
                                 fieldWithPath("accompanyPostShortResponses[].updatedAt").type(
-                                        STRING).description("작성 날짜")  
+                                        STRING).description("작성 날짜")
                         ))
                 );
     }
-  
+
     @Test
     @WithCustomMockUser
     @DisplayName("특정 회원이 작성한 동행 구인 댓글 목록을 조회할 수 있다. - 최초 요청")
@@ -1744,11 +1744,11 @@ class AccompanyControllerTest {
                                 fieldWithPath("accompanyCommentShortResponses[].content").type(
                                         STRING).description("동행 구인 댓글 내용"),
                                 fieldWithPath("accompanyCommentShortResponses[].updatedAt").type(
-                                        STRING).description("작성 날짜") 
+                                        STRING).description("작성 날짜")
                         ))
                 );
-    }       
-          
+    }
+
     @Test
     @WithCustomMockUser
     @DisplayName("특정 회원이 받은 동행 구인 후기를 조회할 수 있다. - 최초 요청")
@@ -1905,6 +1905,121 @@ class AccompanyControllerTest {
                                         .description("작성 날짜"),
                                 fieldWithPath("reviewResponses[].isAccompanyReview").type(BOOLEAN)
                                         .description("동행 후기/공연 후기 여부, 동행 후기면 true, 공연 후기면 false")
+                        ))
+                );
+    }
+
+    @Test
+    @DisplayName("특정 공연에 대한 동행 구인글 목록을 조회할 수 있다. - 최초 요청")
+    void success_getAccompanyPostsByConcertFirst() throws Exception {
+        // given
+        Member member = MemberDataFactory.createMember();
+        memberRepository.save(member);
+
+        Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
+
+        int size = 3;
+        List<AccompanyPost> accompanyPosts = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, size, concert));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/accompanies/posts/concerts/{concertId}", concert.getId())
+                        .param("size", String.valueOf(size))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("{ClassName}/getAccompanyPostsByConcertFirst",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("concertId").description("동행 구인글을 조회할 공연 id")
+                        ),
+                        queryParameters(
+                                parameterWithName("size").description(
+                                        "조회할 동행 구인글 개수, 값 넣지 않으면 기본 10개").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("hasNext").type(BOOLEAN)
+                                        .description("다음 동행 구인글 정보 존재 여부"),
+                                fieldWithPath("accompanyPostConcertResponses").type(ARRAY)
+                                        .description("동행 구인글 목록"),
+                                fieldWithPath("accompanyPostConcertResponses[].id").type(NUMBER)
+                                        .description("동행 구인글 아이디"),
+                                fieldWithPath("accompanyPostConcertResponses[].nickname").type(
+                                        STRING).description("동행 구인글 작성자 이름"),
+                                fieldWithPath("accompanyPostConcertResponses[].title").type(STRING)
+                                        .description("동행 구인글 제목"),
+                                fieldWithPath("accompanyPostConcertResponses[].content").type(
+                                        STRING).description("동행 구인글 내용"),
+                                fieldWithPath("accompanyPostConcertResponses[].viewCount").type(
+                                        NUMBER).description("조회 수"),
+                                fieldWithPath("accompanyPostConcertResponses[].commentCount").type(
+                                        NUMBER).description("댓글 수"),
+                                fieldWithPath("accompanyPostConcertResponses[].updatedAt").type(
+                                        STRING).description("작성 날짜")
+                        ))
+                );
+    }
+
+    @Test
+    @DisplayName("특정 공연에 대한 동행 구인글 목록을 조회할 수 있다. - 이후 요청")
+    void success_getAccompanyPostsByConcertAfterFirst() throws Exception {
+        // given
+        Member member = MemberDataFactory.createMember();
+        memberRepository.save(member);
+
+        Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
+
+        int size = 3;
+        List<AccompanyPost> accompanyPosts = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, size, concert));
+
+        long maxId = -1L;
+        for (AccompanyPost accompanyPost : accompanyPosts) {
+            maxId = Math.max(maxId, accompanyPost.getId());
+        }
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/accompanies/posts/concerts/{concertId}", concert.getId())
+                        .param("cursorId", String.valueOf(maxId + 1))
+                        .param("size", String.valueOf(size))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("{ClassName}/getAccompanyPostsByConcertAfterFirst",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("concertId").description("동행 구인글을 조회할 공연 id")
+                        ),
+                        queryParameters(
+                                parameterWithName("cursorId").description("마지막으로 받은 동행 구인글 아이디"),
+                                parameterWithName("size").description(
+                                        "조회할 동행 구인글 개수, 값 넣지 않으면 기본 10개").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("hasNext").type(BOOLEAN)
+                                        .description("다음 동행 구인글 정보 존재 여부"),
+                                fieldWithPath("accompanyPostConcertResponses").type(ARRAY)
+                                        .description("동행 구인글 목록"),
+                                fieldWithPath("accompanyPostConcertResponses[].id").type(NUMBER)
+                                        .description("동행 구인글 아이디"),
+                                fieldWithPath("accompanyPostConcertResponses[].nickname").type(
+                                        STRING).description("동행 구인글 작성자 이름"),
+                                fieldWithPath("accompanyPostConcertResponses[].title").type(STRING)
+                                        .description("동행 구인글 제목"),
+                                fieldWithPath("accompanyPostConcertResponses[].content").type(
+                                        STRING).description("동행 구인글 내용"),
+                                fieldWithPath("accompanyPostConcertResponses[].viewCount").type(
+                                        NUMBER).description("조회 수"),
+                                fieldWithPath("accompanyPostConcertResponses[].commentCount").type(
+                                        NUMBER).description("댓글 수"),
+                                fieldWithPath("accompanyPostConcertResponses[].updatedAt").type(
+                                        STRING).description("작성 날짜")
                         ))
                 );
     }

--- a/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
+++ b/src/test/java/com/gogoring/dongoorami/accompany/repository/AccompanyPostRepositoryTest.java
@@ -290,6 +290,33 @@ class AccompanyPostRepositoryTest {
                 .toList()).doesNotContain(maxId);
     }
 
+    @Test
+    @DisplayName("id 내림차순으로 특정 공연에 대한 동행 구인글 목록을 조회할 수 있다.")
+    void success_findAllByConcert() {
+        // given
+        Member member = MemberDataFactory.createMember();
+        memberRepository.save(member);
+
+        Concert concert = concertRepository.save(ConcertDataFactory.createConcert());
+
+        int size = 3;
+        List<AccompanyPost> accompanyPosts = accompanyPostRepository.saveAll(
+                createAccompanyPosts(member, size + 1, concert));
+
+        long maxId = -1L;
+        for (AccompanyPost accompanyPost : accompanyPosts) {
+            maxId = Math.max(maxId, accompanyPost.getId());
+        }
+
+        // when
+        Slice<AccompanyPost> slice = accompanyPostRepository.findAllByConcert(maxId, size, concert);
+
+        // then
+        Assertions.assertThat(slice.getSize()).isEqualTo(size);
+        Assertions.assertThat(slice.getContent().stream().map(AccompanyPost::getId)
+                .toList()).doesNotContain(maxId);
+    }
+
     private boolean isAccompanyPostEqualsAccompanyPostFilterRequest(AccompanyPost accompanyPost,
             AccompanyPostFilterRequest accompanyPostFilterRequest) {
         return ((accompanyPostFilterRequest.getGender() == null || accompanyPost.getGender()


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #73 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 특정 공연에 대한 동행 구인글 목록 조회 api 구현

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
